### PR TITLE
Adding support for parameter constraints to all logit-type models.

### DIFF
--- a/pylogit/asym_logit.py
+++ b/pylogit/asym_logit.py
@@ -904,6 +904,7 @@ class MNAL(base_mcm.MNDC_Model):
                 gradient_tol=1e-06,
                 maxiter=1000,
                 ridge=None,
+                constrained_pos=None,
                 **kwargs):
         """
         Parameters
@@ -956,6 +957,11 @@ class MNAL(base_mcm.MNDC_Model):
             scalar is passed, then that scalar determines the ridge penalty for
             the optimization. The scalar should be greater than or equal to
             zero. Default `== None`.
+        constrained_pos : list or None, optional.
+            Denotes the positions of the array of estimated parameters that are
+            not to change from their initial values. If a list is passed, the
+            elements are to be integers where no such integer is greater than
+            `init_vals.size.` Default == None.
 
         Returns
         -------
@@ -1039,7 +1045,8 @@ class MNAL(base_mcm.MNDC_Model):
                                        mapping_res,
                                        ridge,
                                        zero_vector,
-                                       split_param_vec)
+                                       split_param_vec,
+                                       constrained_pos=constrained_pos)
         # Set the derivative functions for estimation
         asym_estimator.set_derivatives()
 

--- a/pylogit/clog_log.py
+++ b/pylogit/clog_log.py
@@ -599,6 +599,7 @@ class MNCL(base_mcm.MNDC_Model):
                 gradient_tol=1e-06,
                 maxiter=1000,
                 ridge=None,
+                constrained_pos=None,
                 **kwargs):
         """
         Parameters
@@ -645,6 +646,11 @@ class MNCL(base_mcm.MNDC_Model):
             scalar is passed, then that scalar determines the ridge penalty for
             the optimization. The scalar should be greater than or equal to
             zero. Default `== None`.
+        constrained_pos : list or None, optional.
+            Denotes the positions of the array of estimated parameters that are
+            not to change from their initial values. If a list is passed, the
+            elements are to be integers where no such integer is greater than
+            `init_values.size.` Default == None.
 
         Returns
         -------
@@ -705,7 +711,8 @@ class MNCL(base_mcm.MNDC_Model):
                                        mapping_res,
                                        ridge,
                                        zero_vector,
-                                       split_param_vec)
+                                       split_param_vec,
+                                       constrained_pos=constrained_pos)
         # Set the derivative functions for estimation
         clog_estimator.set_derivatives()
 

--- a/pylogit/conditional_logit.py
+++ b/pylogit/conditional_logit.py
@@ -296,6 +296,7 @@ class MNL(base_mcm.MNDC_Model):
                 gradient_tol=1e-06,
                 maxiter=1000,
                 ridge=None,
+                constrained_pos=None,
                 **kwargs):
         """
         Parameters
@@ -322,6 +323,11 @@ class MNL(base_mcm.MNDC_Model):
             Determines whether or not ridge regression is performed. If a
             scalar is passed, then that scalar determines the ridge penalty for
             the optimization. Default `== None`.
+        constrained_pos : list or None, optional.
+            Denotes the positions of the array of estimated parameters that are
+            not to change from their initial values. If a list is passed, the
+            elements are to be integers where no such integer is greater than
+            `init_vals.size.` Default == None.
 
         Returns
         -------
@@ -353,7 +359,8 @@ class MNL(base_mcm.MNDC_Model):
                                      mapping_res,
                                      ridge,
                                      zero_vector,
-                                     split_param_vec)
+                                     split_param_vec,
+                                     constrained_pos=constrained_pos)
         # Set the derivative functions for estimation
         mnl_estimator.set_derivatives()
 

--- a/pylogit/estimation.py
+++ b/pylogit/estimation.py
@@ -246,6 +246,11 @@ class LogitTypeEstimator(EstimationObj):
         coefficients. For each of these arrays, if this model does not contain
         the particular type of parameter, the callable should place a `None` in
         its place in the tuple.
+    constrained_pos : list or None, optional.
+        Denotes the positions of the array of estimated parameters that are
+        not to change from their initial values. If a list is passed, the
+        elements are to be integers where no such integer is greater than
+        `num_params` Default == None.
 
     Attributes
     ----------
@@ -258,13 +263,16 @@ class LogitTypeEstimator(EstimationObj):
                  mapping_dict,
                  ridge,
                  zero_vector,
-                 split_params):
+                 split_params,
+                 constrained_pos=None):
 
+    	kwargs = {"constrained_pos": constrained_pos}
         super(LogitTypeEstimator, self).__init__(model_obj,
                                                  mapping_dict,
                                                  ridge,
                                                  zero_vector,
-                                                 split_params)
+                                                 split_params,
+                                                 **kwargs)
 
         return None
 
@@ -377,24 +385,6 @@ class LogitTypeEstimator(EstimationObj):
                 self.ridge]
 
         return cc.calc_fisher_info_matrix(*args)
-
-    def calc_neg_log_likelihood_and_neg_gradient(self, params):
-        """
-        Calculates and returns the negative of the log-likelihood and the
-        negative of the gradient. This function is used as the objective
-        function in scipy.optimize.minimize.
-        """
-        neg_log_likelihood = -1 * self.convenience_calc_log_likelihood(params)
-        neg_gradient = -1 * self.convenience_calc_gradient(params)
-
-        return neg_log_likelihood, neg_gradient
-
-    def calc_neg_hessian(self, params):
-        """
-        Calculate and return the negative of the hessian for this model and
-        dataset.
-        """
-        return -1 * self.convenience_calc_hessian(params)
 
 
 def calc_individual_chi_squares(residuals,

--- a/pylogit/scobit.py
+++ b/pylogit/scobit.py
@@ -714,6 +714,7 @@ class MNSL(base_mcm.MNDC_Model):
                 gradient_tol=1e-06,
                 maxiter=1000,
                 ridge=None,
+                constrained_pos=None,
                 **kwargs):
         """
         Parameters
@@ -765,6 +766,11 @@ class MNSL(base_mcm.MNDC_Model):
             scalar is passed, then that scalar determines the ridge penalty for
             the optimization. The scalar should be greater than or equal to
             zero. Default `== None`.
+        constrained_pos : list or None, optional.
+            Denotes the positions of the array of estimated parameters that are
+            not to change from their initial values. If a list is passed, the
+            elements are to be integers where no such integer is greater than
+            `init_vals.size.` Default == None.
 
         Returns
         -------
@@ -846,7 +852,8 @@ class MNSL(base_mcm.MNDC_Model):
                                            mapping_res,
                                            ridge,
                                            zero_vector,
-                                           split_param_vec)
+                                           split_param_vec,
+                                           constrained_pos=constrained_pos)
         # Set the derivative functions for estimation
         scobit_estimator.set_derivatives()
 

--- a/pylogit/uneven_logit.py
+++ b/pylogit/uneven_logit.py
@@ -715,6 +715,7 @@ class MNUL(base_mcm.MNDC_Model):
                 gradient_tol=1e-06,
                 maxiter=1000,
                 ridge=None,
+                constrained_pos=None,
                 **kwargs):
         """
         Parameters
@@ -766,6 +767,11 @@ class MNUL(base_mcm.MNDC_Model):
             scalar is passed, then that scalar determines the ridge penalty for
             the optimization. The scalar should be greater than or equal to
             zero. Default `== None`.
+        constrained_pos : list or None, optional.
+            Denotes the positions of the array of estimated parameters that are
+            not to change from their initial values. If a list is passed, the
+            elements are to be integers where no such integer is greater than
+            `init_vals.size.` Default == None.
 
         Returns
         -------
@@ -848,7 +854,8 @@ class MNUL(base_mcm.MNDC_Model):
                                            mapping_res,
                                            ridge,
                                            zero_vector,
-                                           split_param_vec)
+                                           split_param_vec,
+                                           constrained_pos=constrained_pos)
         # Set the derivative functions for estimation
         uneven_estimator.set_derivatives()
 


### PR DESCRIPTION
All logit-type models now support parameter constraints. During estimation, all models can make use of the "constrained_pos" kwarg in the fit_mle() function.