### PR TITLE
Small working example of `just_point`

### DIFF
--- a/examples/point estimation example/.ipynb_checkpoints/Small working example-checkpoint.ipynb
+++ b/examples/point estimation example/.ipynb_checkpoints/Small working example-checkpoint.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/point estimation example/Small working example.ipynb
+++ b/examples/point estimation example/Small working example.ipynb
@@ -1,0 +1,698 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example for bug related to point estimation "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import pylogit as pl\n",
+    "from collections import defaultdict, OrderedDict\n",
+    "from functools import reduce\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a variable for the path to the long format data for\n",
+    "# the multinomial choice model\n",
+    "PATH = 'spring_2016_all_bay_area_long_format_plus_cross_bay_col.csv'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The columns of bike_data are:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Index(['household_id', 'person_id', 'tour_id', 'observation_id', 'mode_id',\n",
+       "       'choice', 'tour_origin_taz', 'primary_dest_taz', 'total_travel_time',\n",
+       "       'total_travel_cost', 'total_travel_distance', 'age', 'household_size',\n",
+       "       'household_income', 'household_income_values', 'transit_subsidy',\n",
+       "       'transit_subsidy_amount', 'num_cars', 'num_licensed_drivers',\n",
+       "       'cross_bay', 'oakland_and_berkeley', 'survey_id', 'gender',\n",
+       "       'non_relative_flag', 'num_pre_school', 'num_school_aged', 'married',\n",
+       "       'parent', 'income_category_1', 'income_category_2', 'income_category_3',\n",
+       "       'income_category_4', 'income_category_5', 'income_category_6',\n",
+       "       'income_category_7', 'income_category_8', 'income_category_9',\n",
+       "       'income_category_10', 'income_unknown', 'ln_drive_cost',\n",
+       "       'ln_drive_cost_sq', 'total_travel_time_10x', 'total_travel_time_tenth',\n",
+       "       'high_income', 'medium_income', 'low_income', 'high_income_cost',\n",
+       "       'medium_income_cost', 'low_income_cost', 'unknown_income_cost',\n",
+       "       'high_income_ln_cost', 'medium_income_ln_cost', 'low_income_ln_cost',\n",
+       "       'unknown_income_ln_cost', 'cars_per_licensed_drivers', 'num_kids',\n",
+       "       'family_in_household', 'married_woman', 'cost_per_distance',\n",
+       "       'intercept', 'cost_per_distance_10$_per_mi',\n",
+       "       'total_travel_time_tenth_min'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Reading data from the specified PATH\n",
+    "bike_data_long = pd.read_csv(PATH)\n",
+    "\n",
+    "# If in previous work we accidentally saved the index with the dataframe\n",
+    "# remove the old index from the data\n",
+    "if \"Unnamed: 0\" in bike_data_long.columns:\n",
+    "    del bike_data_long[\"Unnamed: 0\"]\n",
+    "\n",
+    "print(\"The columns of bike_data are:\")\n",
+    "bike_data_long.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Drive Alone           0.428322\n",
+       "Shared Ride 2         0.158841\n",
+       "Shared Ride 3+        0.139860\n",
+       "Walk-Transit-Walk     0.103397\n",
+       "Drive-Transit-Walk    0.015485\n",
+       "Walk-Transit-Drive    0.013237\n",
+       "Walk                  0.094406\n",
+       "Bike                  0.046454\n",
+       "Name: Mode Shares, dtype: float64"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Look at the mode shares in the data set\n",
+    "alt_id_to_mode_name = {1: \"Drive Alone\",\n",
+    "                       2: \"Shared Ride 2\",\n",
+    "                       3: \"Shared Ride 3+\",\n",
+    "                       4: \"Walk-Transit-Walk\",\n",
+    "                       5: \"Drive-Transit-Walk\",\n",
+    "                       6: \"Walk-Transit-Drive\",\n",
+    "                       7: \"Walk\",\n",
+    "                       8: \"Bike\"}\n",
+    "\n",
+    "mode_counts = bike_data_long.loc[bike_data_long.choice == 1,\n",
+    "                                 \"mode_id\"].value_counts().loc[range(1, 9)]\n",
+    "\n",
+    "mode_shares = mode_counts / bike_data_long.observation_id.max()\n",
+    "mode_shares.index = [alt_id_to_mode_name[x] for x in mode_shares.index.values]\n",
+    "mode_shares.name = \"Mode Shares\"\n",
+    "mode_shares"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create my specification and variable names for the basic MNL model\n",
+    "# NOTE: - Keys should be variables within the long format dataframe.\n",
+    "#         The sole exception to this is the \"intercept\" key.\n",
+    "#       - For the specification dictionary, the values should be lists\n",
+    "#         or lists of lists. Within a list, or within the inner-most\n",
+    "#         list should be the alternative ID's of the alternative whose\n",
+    "#         utility specification the explanatory variable is entering.\n",
+    "\n",
+    "mnl_specification = OrderedDict()\n",
+    "mnl_names = OrderedDict()\n",
+    "\n",
+    "mnl_specification[\"intercept\"] = [2, 3, 4, 5, 6, 7, 8]\n",
+    "mnl_names[\"intercept\"] = ['ASC Shared Ride: 2',\n",
+    "                          'ASC Shared Ride: 3+',\n",
+    "                          'ASC Walk-Transit-Walk',\n",
+    "                          'ASC Drive-Transit-Walk',\n",
+    "                          'ASC Walk-Transit-Drive',\n",
+    "                          'ASC Walk',\n",
+    "                          'ASC Bike']\n",
+    "\n",
+    "mnl_specification[\"total_travel_time\"] = [[1, 2, 3], [4, 5, 6]]\n",
+    "mnl_names[\"total_travel_time\"] = ['Travel Time, units:min (All Auto Modes)',\n",
+    "                                  'Travel Time, units:min (All Transit Modes)']\n",
+    "\n",
+    "mnl_specification[\"total_travel_cost\"] = [[4, 5, 6]]\n",
+    "mnl_names[\"total_travel_cost\"] = ['Travel Cost, units:$ (All Transit Modes)']\n",
+    "\n",
+    "mnl_specification[\"cost_per_distance\"] = [1, 2, 3]\n",
+    "mnl_names[\"cost_per_distance\"] = [\"Travel Cost per Distance, units:$/mi (Drive Alone)\",\n",
+    "                                  \"Travel Cost per Distance, units:$/mi (SharedRide-2)\",\n",
+    "                                  \"Travel Cost per Distance, units:$/mi (SharedRide-3+)\"]\n",
+    "\n",
+    "mnl_specification[\"cars_per_licensed_drivers\"] = [[1, 2, 3]]\n",
+    "mnl_names[\"cars_per_licensed_drivers\"] = [\"Autos per licensed drivers (All Auto Modes)\"]\n",
+    "\n",
+    "mnl_specification[\"total_travel_distance\"] = [7, 8]\n",
+    "mnl_names[\"total_travel_distance\"] = ['Travel Distance, units:mi (Walk)',\n",
+    "                                      'Travel Distance, units:mi (Bike)']\n",
+    "\n",
+    "# mnl_specification[\"cross_bay\"] = [[2, 3], [4, 5, 6]]\n",
+    "# mnl_names[\"cross_bay\"] = [\"Cross-Bay Tour (Shared Ride 2 & 3+)\",\n",
+    "#                           \"Cross-Bay Tour (All Transit Modes)\"]\n",
+    "mnl_specification[\"cross_bay\"] = [[2, 3]]\n",
+    "mnl_names[\"cross_bay\"] = [\"Cross-Bay Tour (Shared Ride 2 & 3+)\"]\n",
+    "\n",
+    "mnl_specification[\"household_size\"] = [[2, 3]]\n",
+    "mnl_names[\"household_size\"] = ['Household Size (Shared Ride 2 & 3+)']\n",
+    "\n",
+    "mnl_specification[\"num_kids\"] = [[2, 3]]\n",
+    "mnl_names[\"num_kids\"] = [\"Number of Kids in Household (Shared Ride 2 & 3+)\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Log-likelihood at zero: -7,599.7019\n",
+      "Initial Log-likelihood: -7,599.7019\n",
+      "Estimation Time for Point Estimation: 0.16 seconds.\n",
+      "Final log-likelihood: -5,073.4276\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/mobouzaghrane/opt/anaconda3/lib/python3.7/site-packages/scipy/optimize/_minimize.py:505: RuntimeWarning: Method BFGS does not use Hessian information (hess).\n",
+      "  RuntimeWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"simpletable\">\n",
+       "<caption>Multinomial Logit Model Regression Results</caption>\n",
+       "<tr>\n",
+       "  <th>Dep. Variable:</th>         <td>choice</td>          <th>  No. Observations:  </th>    <td>4,004</td>  \n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Model:</th>         <td>Multinomial Logit Model</td> <th>  Df Residuals:      </th>    <td>3,985</td>  \n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Method:</th>                  <td>MLE</td>           <th>  Df Model:          </th>     <td>19</td>    \n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Date:</th>             <td>Sun, 12 Apr 2020</td>     <th>  Pseudo R-squ.:     </th>    <td>0.332</td>  \n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Time:</th>                 <td>14:44:17</td>         <th>  Pseudo R-bar-squ.: </th>    <td>0.330</td>  \n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>AIC:</th>                 <td>10,184.855</td>        <th>  Log-Likelihood:    </th> <td>-5,073.428</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>BIC:</th>                 <td>10,304.461</td>        <th>  LL-Null:           </th> <td>-7,599.702</td>\n",
+       "</tr>\n",
+       "</table>\n",
+       "<table class=\"simpletable\">\n",
+       "<tr>\n",
+       "                            <td></td>                              <th>coef</th>     <th>std err</th>      <th>z</th>      <th>P>|z|</th>  <th>[0.025</th>    <th>0.975]</th>  \n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>ASC Shared Ride: 2</th>                                   <td>   -1.0097</td> <td>    0.486</td> <td>   -2.079</td> <td> 0.038</td> <td>   -1.962</td> <td>   -0.058</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>ASC Shared Ride: 3+</th>                                  <td>    3.4619</td> <td>    1.064</td> <td>    3.254</td> <td> 0.001</td> <td>    1.377</td> <td>    5.547</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>ASC Walk-Transit-Walk</th>                                <td>   -0.3921</td> <td>    0.288</td> <td>   -1.360</td> <td> 0.174</td> <td>   -0.957</td> <td>    0.173</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>ASC Drive-Transit-Walk</th>                               <td>   -2.6220</td> <td>    0.303</td> <td>   -8.660</td> <td> 0.000</td> <td>   -3.215</td> <td>   -2.029</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>ASC Walk-Transit-Drive</th>                               <td>   -2.9773</td> <td>    0.306</td> <td>   -9.725</td> <td> 0.000</td> <td>   -3.577</td> <td>   -2.377</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>ASC Walk</th>                                             <td>    1.5541</td> <td>    0.305</td> <td>    5.101</td> <td> 0.000</td> <td>    0.957</td> <td>    2.151</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>ASC Bike</th>                                             <td>   -1.1059</td> <td>    0.305</td> <td>   -3.628</td> <td> 0.000</td> <td>   -1.703</td> <td>   -0.508</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Travel Time, units:min (All Auto Modes)</th>              <td>   -0.0760</td> <td>    0.006</td> <td>  -13.728</td> <td> 0.000</td> <td>   -0.087</td> <td>   -0.065</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Travel Time, units:min (All Transit Modes)</th>           <td>   -0.0274</td> <td>    0.002</td> <td>  -12.768</td> <td> 0.000</td> <td>   -0.032</td> <td>   -0.023</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Travel Cost, units:$ (All Transit Modes)</th>             <td>   -0.1273</td> <td>    0.037</td> <td>   -3.472</td> <td> 0.001</td> <td>   -0.199</td> <td>   -0.055</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Travel Cost per Distance, units:$/mi (Drive Alone)</th>   <td>   -5.0613</td> <td>    1.377</td> <td>   -3.675</td> <td> 0.000</td> <td>   -7.760</td> <td>   -2.362</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Travel Cost per Distance, units:$/mi (SharedRide-2)</th>  <td>  -20.3194</td> <td>    4.548</td> <td>   -4.467</td> <td> 0.000</td> <td>  -29.234</td> <td>  -11.405</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Travel Cost per Distance, units:$/mi (SharedRide-3+)</th> <td>  -90.9224</td> <td>   14.748</td> <td>   -6.165</td> <td> 0.000</td> <td> -119.829</td> <td>  -62.016</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Autos per licensed drivers (All Auto Modes)</th>          <td>    1.2134</td> <td>    0.129</td> <td>    9.408</td> <td> 0.000</td> <td>    0.961</td> <td>    1.466</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Travel Distance, units:mi (Walk)</th>                     <td>   -1.0272</td> <td>    0.050</td> <td>  -20.437</td> <td> 0.000</td> <td>   -1.126</td> <td>   -0.929</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Travel Distance, units:mi (Bike)</th>                     <td>   -0.2873</td> <td>    0.024</td> <td>  -11.896</td> <td> 0.000</td> <td>   -0.335</td> <td>   -0.240</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Cross-Bay Tour (Shared Ride 2 & 3+)</th>                  <td>    0.9280</td> <td>    0.327</td> <td>    2.839</td> <td> 0.005</td> <td>    0.287</td> <td>    1.569</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Household Size (Shared Ride 2 & 3+)</th>                  <td>    0.1136</td> <td>    0.045</td> <td>    2.523</td> <td> 0.012</td> <td>    0.025</td> <td>    0.202</td>\n",
+       "</tr>\n",
+       "<tr>\n",
+       "  <th>Number of Kids in Household (Shared Ride 2 & 3+)</th>     <td>    0.6868</td> <td>    0.054</td> <td>   12.820</td> <td> 0.000</td> <td>    0.582</td> <td>    0.792</td>\n",
+       "</tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<class 'statsmodels.iolib.summary.Summary'>\n",
+       "\"\"\"\n",
+       "                     Multinomial Logit Model Regression Results                    \n",
+       "===================================================================================\n",
+       "Dep. Variable:                      choice   No. Observations:                4,004\n",
+       "Model:             Multinomial Logit Model   Df Residuals:                    3,985\n",
+       "Method:                                MLE   Df Model:                           19\n",
+       "Date:                     Sun, 12 Apr 2020   Pseudo R-squ.:                   0.332\n",
+       "Time:                             14:44:17   Pseudo R-bar-squ.:               0.330\n",
+       "AIC:                            10,184.855   Log-Likelihood:             -5,073.428\n",
+       "BIC:                            10,304.461   LL-Null:                    -7,599.702\n",
+       "========================================================================================================================\n",
+       "                                                           coef    std err          z      P>|z|      [0.025      0.975]\n",
+       "------------------------------------------------------------------------------------------------------------------------\n",
+       "ASC Shared Ride: 2                                      -1.0097      0.486     -2.079      0.038      -1.962      -0.058\n",
+       "ASC Shared Ride: 3+                                      3.4619      1.064      3.254      0.001       1.377       5.547\n",
+       "ASC Walk-Transit-Walk                                   -0.3921      0.288     -1.360      0.174      -0.957       0.173\n",
+       "ASC Drive-Transit-Walk                                  -2.6220      0.303     -8.660      0.000      -3.215      -2.029\n",
+       "ASC Walk-Transit-Drive                                  -2.9773      0.306     -9.725      0.000      -3.577      -2.377\n",
+       "ASC Walk                                                 1.5541      0.305      5.101      0.000       0.957       2.151\n",
+       "ASC Bike                                                -1.1059      0.305     -3.628      0.000      -1.703      -0.508\n",
+       "Travel Time, units:min (All Auto Modes)                 -0.0760      0.006    -13.728      0.000      -0.087      -0.065\n",
+       "Travel Time, units:min (All Transit Modes)              -0.0274      0.002    -12.768      0.000      -0.032      -0.023\n",
+       "Travel Cost, units:$ (All Transit Modes)                -0.1273      0.037     -3.472      0.001      -0.199      -0.055\n",
+       "Travel Cost per Distance, units:$/mi (Drive Alone)      -5.0613      1.377     -3.675      0.000      -7.760      -2.362\n",
+       "Travel Cost per Distance, units:$/mi (SharedRide-2)    -20.3194      4.548     -4.467      0.000     -29.234     -11.405\n",
+       "Travel Cost per Distance, units:$/mi (SharedRide-3+)   -90.9224     14.748     -6.165      0.000    -119.829     -62.016\n",
+       "Autos per licensed drivers (All Auto Modes)              1.2134      0.129      9.408      0.000       0.961       1.466\n",
+       "Travel Distance, units:mi (Walk)                        -1.0272      0.050    -20.437      0.000      -1.126      -0.929\n",
+       "Travel Distance, units:mi (Bike)                        -0.2873      0.024    -11.896      0.000      -0.335      -0.240\n",
+       "Cross-Bay Tour (Shared Ride 2 & 3+)                      0.9280      0.327      2.839      0.005       0.287       1.569\n",
+       "Household Size (Shared Ride 2 & 3+)                      0.1136      0.045      2.523      0.012       0.025       0.202\n",
+       "Number of Kids in Household (Shared Ride 2 & 3+)         0.6868      0.054     12.820      0.000       0.582       0.792\n",
+       "========================================================================================================================\n",
+       "\"\"\""
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Estimate the basic MNL model, using the hessian and newton-conjugate gradient\n",
+    "mnl_model = pl.create_choice_model(data=bike_data_long,\n",
+    "                                   alt_id_col=\"mode_id\",\n",
+    "                                   obs_id_col=\"observation_id\",\n",
+    "                                   choice_col=\"choice\",\n",
+    "                                   specification=mnl_specification,\n",
+    "                                   model_type=\"MNL\",\n",
+    "                                   names=mnl_names)\n",
+    "\n",
+    "num_vars = len(reduce(lambda x, y: x + y, mnl_names.values()))\n",
+    "\n",
+    "# Note newton-cg used to ensure convergence to a point where gradient\n",
+    "# is essentially zero for all dimensions.\n",
+    "mnl_model.fit_mle(np.zeros(num_vars),\n",
+    "                  method=\"BFGS\")\n",
+    "\n",
+    "# Look at the estimation results\n",
+    "mnl_model.get_statsmodels_summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Showing problem with just_point"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/mobouzaghrane/opt/anaconda3/lib/python3.7/site-packages/pylogit/choice_tools.py:703: FutureWarning: arrays to stack must be passed as a \"sequence\" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.\n",
+      "  design_matrix = np.hstack((x[:, None] for x in independent_vars))\n",
+      "/Users/mobouzaghrane/opt/anaconda3/lib/python3.7/site-packages/scipy/optimize/_minimize.py:505: RuntimeWarning: Method BFGS does not use Hessian information (hess).\n",
+      "  RuntimeWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Estimate the basic MNL model, using the hessian and newton-conjugate gradient\n",
+    "mnl_model_point = pl.create_choice_model(data=bike_data_long,\n",
+    "                                   alt_id_col=\"mode_id\",\n",
+    "                                   obs_id_col=\"observation_id\",\n",
+    "                                   choice_col=\"choice\",\n",
+    "                                   specification=mnl_specification,\n",
+    "                                   model_type=\"MNL\",\n",
+    "                                   names=mnl_names)\n",
+    "\n",
+    "num_vars = len(reduce(lambda x, y: x + y, mnl_names.values()))\n",
+    "\n",
+    "# Note newton-cg used to ensure convergence to a point where gradient\n",
+    "# is essentially zero for all dimensions.\n",
+    "model_dict=mnl_model_point.fit_mle(np.zeros(num_vars),\n",
+    "                  method=\"BFGS\", just_point=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "      fun: 5073.427610337385\n",
+       " hess_inv: array([[ 1.93892758e-01,  2.18887697e-01,  2.19656499e-02,\n",
+       "         2.04902258e-02,  1.98483021e-02,  2.38688594e-02,\n",
+       "         2.09293653e-02, -1.52853164e-04, -6.36532542e-05,\n",
+       "         6.04326760e-04,  1.23913641e-01, -1.47025518e+00,\n",
+       "        -2.48211013e+00, -2.18727040e-03, -9.79755186e-04,\n",
+       "         1.05988600e-04,  8.74351405e-02, -3.97677736e-03,\n",
+       "         2.66158202e-03],\n",
+       "       [ 2.18887697e-01,  8.60411078e-01,  9.21440564e-03,\n",
+       "         1.15555047e-02,  7.37823526e-03,  5.55279599e-03,\n",
+       "         4.32785362e-04, -3.52803695e-04, -1.25194482e-04,\n",
+       "        -2.13756083e-03, -2.35991673e-02, -1.99277100e+00,\n",
+       "        -1.14469778e+01,  5.48120392e-03, -2.85309861e-03,\n",
+       "        -2.69071372e-04,  1.46764165e-01, -3.38940285e-03,\n",
+       "         1.44533147e-03],\n",
+       "       [ 2.19656499e-02,  9.21440564e-03,  7.32767277e-02,\n",
+       "         6.76534407e-02,  6.83888942e-02,  6.12784583e-02,\n",
+       "         6.13545827e-02, -4.47740084e-04, -2.52545997e-04,\n",
+       "         1.27381909e-03,  2.87910822e-01,  3.17609170e-01,\n",
+       "         6.25335678e-01,  8.70374185e-03, -9.72195082e-04,\n",
+       "        -1.00958921e-03,  6.64480711e-03, -2.88611741e-04,\n",
+       "         3.55302929e-04],\n",
+       "       [ 2.04902258e-02,  1.15555047e-02,  6.76534407e-02,\n",
+       "         8.08710626e-02,  6.58899486e-02,  6.09229480e-02,\n",
+       "         6.04201396e-02, -2.71398960e-04, -1.93042408e-04,\n",
+       "         1.49324440e-03,  2.78784047e-01,  3.10182855e-01,\n",
+       "         5.62010770e-01,  9.26768552e-03, -7.16512954e-04,\n",
+       "        -5.71337765e-04,  6.86212760e-03, -2.05622688e-04,\n",
+       "         4.18477290e-04],\n",
+       "       [ 1.98483021e-02,  7.37823526e-03,  6.83888942e-02,\n",
+       "         6.58899486e-02,  8.44237890e-02,  6.13143099e-02,\n",
+       "         6.10958529e-02, -2.83082208e-04, -1.89217572e-04,\n",
+       "         1.43829802e-03,  2.82458788e-01,  3.29528059e-01,\n",
+       "         6.36576959e-01,  9.43208007e-03, -6.05473187e-04,\n",
+       "        -6.03935724e-04,  5.42771711e-03, -3.57938594e-04,\n",
+       "         3.90071993e-04],\n",
+       "       [ 2.38688594e-02,  5.55279599e-03,  6.12784583e-02,\n",
+       "         6.09229480e-02,  6.13143099e-02,  7.96560042e-02,\n",
+       "         6.73831768e-02, -1.83868679e-04, -1.38463446e-04,\n",
+       "         3.03048741e-03,  2.91697766e-01,  3.09373300e-01,\n",
+       "         6.87253797e-01,  1.05767120e-02, -5.23918839e-03,\n",
+       "        -9.26602848e-04,  7.23903101e-03, -5.57896533e-04,\n",
+       "         1.07492848e-03],\n",
+       "       [ 2.09293653e-02,  4.32785362e-04,  6.13545827e-02,\n",
+       "         6.04201396e-02,  6.10958529e-02,  6.73831768e-02,\n",
+       "         7.99529614e-02, -1.76920729e-04, -1.37448092e-04,\n",
+       "         3.13141792e-03,  2.95096841e-01,  3.41199192e-01,\n",
+       "         7.62786974e-01,  9.91306466e-03, -1.08888891e-03,\n",
+       "        -2.57658146e-03,  6.82910182e-03, -5.80710283e-04,\n",
+       "         1.15268767e-03],\n",
+       "       [-1.52853164e-04, -3.52803695e-04, -4.47740084e-04,\n",
+       "        -2.71398960e-04, -2.83082208e-04, -1.83868679e-04,\n",
+       "        -1.76920729e-04,  2.49694265e-05,  6.07527877e-06,\n",
+       "         6.64621235e-05, -1.83320434e-03, -1.74752342e-03,\n",
+       "         2.41308163e-04,  3.43195695e-05,  6.21253611e-05,\n",
+       "         5.04554635e-05, -1.75757282e-04, -2.83877776e-06,\n",
+       "         1.33111064e-05],\n",
+       "       [-6.36532542e-05, -1.25194482e-04, -2.52545997e-04,\n",
+       "        -1.93042408e-04, -1.89217572e-04, -1.38463446e-04,\n",
+       "        -1.37448092e-04,  6.07527877e-06,  3.66556514e-06,\n",
+       "        -1.66382474e-05, -9.34449818e-04, -1.05798127e-03,\n",
+       "        -6.72487539e-04,  6.93283421e-06,  1.21200343e-05,\n",
+       "         1.26803672e-05, -6.77914286e-05,  5.58423000e-07,\n",
+       "         1.27140616e-06],\n",
+       "       [ 6.04326760e-04, -2.13756083e-03,  1.27381909e-03,\n",
+       "         1.49324440e-03,  1.43829802e-03,  3.03048741e-03,\n",
+       "         3.13141792e-03,  6.64621235e-05, -1.66382474e-05,\n",
+       "         1.12189244e-03,  1.39036899e-02,  1.99998778e-02,\n",
+       "         6.57221689e-02,  1.64481879e-04,  2.18938462e-04,\n",
+       "         1.19493981e-04,  7.44367352e-04, -6.02379600e-05,\n",
+       "         7.77548144e-05],\n",
+       "       [ 1.23913641e-01, -2.35991673e-02,  2.87910822e-01,\n",
+       "         2.78784047e-01,  2.82458788e-01,  2.91697766e-01,\n",
+       "         2.95096841e-01, -1.83320434e-03, -9.34449818e-04,\n",
+       "         1.39036899e-02,  1.65687854e+00,  1.74080361e+00,\n",
+       "         4.48228674e+00, -1.15135887e-02, -3.31839699e-03,\n",
+       "        -4.33733912e-03,  4.18248489e-02, -4.39264218e-04,\n",
+       "         1.87853060e-03],\n",
+       "       [-1.47025518e+00, -1.99277100e+00,  3.17609170e-01,\n",
+       "         3.10182855e-01,  3.29528059e-01,  3.09373300e-01,\n",
+       "         3.41199192e-01, -1.74752342e-03, -1.05798127e-03,\n",
+       "         1.99998778e-02,  1.74080361e+00,  1.67912214e+01,\n",
+       "         3.13036296e+01,  1.57468379e-02,  3.95232630e-03,\n",
+       "        -8.50765728e-03, -7.58796780e-01, -7.13941985e-04,\n",
+       "         1.73767758e-03],\n",
+       "       [-2.48211013e+00, -1.14469778e+01,  6.25335678e-01,\n",
+       "         5.62010770e-01,  6.36576959e-01,  6.87253797e-01,\n",
+       "         7.62786974e-01,  2.41308163e-04, -6.72487539e-04,\n",
+       "         6.57221689e-02,  4.48228674e+00,  3.13036296e+01,\n",
+       "         1.65159975e+02, -8.33732328e-02,  3.11645209e-02,\n",
+       "        -7.09239359e-03, -1.88768410e+00, -8.85366811e-03,\n",
+       "         1.92555231e-02],\n",
+       "       [-2.18727040e-03,  5.48120392e-03,  8.70374185e-03,\n",
+       "         9.26768552e-03,  9.43208007e-03,  1.05767120e-02,\n",
+       "         9.91306466e-03,  3.43195695e-05,  6.93283421e-06,\n",
+       "         1.64481879e-04, -1.15135887e-02,  1.57468379e-02,\n",
+       "        -8.33732328e-02,  1.33039581e-02, -2.49535513e-04,\n",
+       "         3.46018108e-05,  2.66816973e-04, -3.49469134e-04,\n",
+       "         4.17352144e-05],\n",
+       "       [-9.79755186e-04, -2.85309861e-03, -9.72195082e-04,\n",
+       "        -7.16512954e-04, -6.05473187e-04, -5.23918839e-03,\n",
+       "        -1.08888891e-03,  6.21253611e-05,  1.21200343e-05,\n",
+       "         2.18938462e-04, -3.31839699e-03,  3.95232630e-03,\n",
+       "         3.11645209e-02, -2.49535513e-04,  2.16681507e-03,\n",
+       "         2.39064658e-04, -5.18520161e-04, -4.87847181e-06,\n",
+       "        -7.49862846e-05],\n",
+       "       [ 1.05988600e-04, -2.69071372e-04, -1.00958921e-03,\n",
+       "        -5.71337765e-04, -6.03935724e-04, -9.26602848e-04,\n",
+       "        -2.57658146e-03,  5.04554635e-05,  1.26803672e-05,\n",
+       "         1.19493981e-04, -4.33733912e-03, -8.50765728e-03,\n",
+       "        -7.09239359e-03,  3.46018108e-05,  2.39064658e-04,\n",
+       "         5.14098057e-04, -2.60021347e-04,  1.12631891e-05,\n",
+       "        -3.97894062e-05],\n",
+       "       [ 8.74351405e-02,  1.46764165e-01,  6.64480711e-03,\n",
+       "         6.86212760e-03,  5.42771711e-03,  7.23903101e-03,\n",
+       "         6.82910182e-03, -1.75757282e-04, -6.77914286e-05,\n",
+       "         7.44367352e-04,  4.18248489e-02, -7.58796780e-01,\n",
+       "        -1.88768410e+00,  2.66816973e-04, -5.18520161e-04,\n",
+       "        -2.60021347e-04,  8.68557272e-02,  5.86669578e-05,\n",
+       "        -7.28272529e-05],\n",
+       "       [-3.97677736e-03, -3.38940285e-03, -2.88611741e-04,\n",
+       "        -2.05622688e-04, -3.57938594e-04, -5.57896533e-04,\n",
+       "        -5.80710283e-04, -2.83877776e-06,  5.58423000e-07,\n",
+       "        -6.02379600e-05, -4.39264218e-04, -7.13941985e-04,\n",
+       "        -8.85366811e-03, -3.49469134e-04, -4.87847181e-06,\n",
+       "         1.12631891e-05,  5.86669578e-05,  1.59399126e-03,\n",
+       "        -1.43800583e-03],\n",
+       "       [ 2.66158202e-03,  1.44533147e-03,  3.55302929e-04,\n",
+       "         4.18477290e-04,  3.90071993e-04,  1.07492848e-03,\n",
+       "         1.15268767e-03,  1.33111064e-05,  1.27140616e-06,\n",
+       "         7.77548144e-05,  1.87853060e-03,  1.73767758e-03,\n",
+       "         1.92555231e-02,  4.17352144e-05, -7.49862846e-05,\n",
+       "        -3.97894062e-05, -7.28272529e-05, -1.43800583e-03,\n",
+       "         2.23735073e-03]])\n",
+       "      jac: array([ 1.60218409e-07, -3.03478167e-07, -4.84198448e-08,  8.26442625e-08,\n",
+       "       -1.75391201e-07, -1.47022421e-07,  2.67460076e-08,  6.25757001e-06,\n",
+       "       -8.27617725e-06, -5.78743347e-07,  9.04420547e-08,  1.11281966e-08,\n",
+       "       -2.38472206e-08,  1.47176241e-07, -8.21541224e-07,  1.26454750e-06,\n",
+       "        2.03630255e-08, -4.97829461e-07, -1.17902459e-07])\n",
+       "  message: 'Desired error not necessarily achieved due to precision loss.'\n",
+       "     nfev: 65\n",
+       "      nit: 56\n",
+       "     njev: 64\n",
+       "   status: 2\n",
+       "  success: False\n",
+       "        x: array([-1.00973468e+00,  3.46190903e+00, -3.92084362e-01, -2.62200851e+00,\n",
+       "       -2.97734115e+00,  1.55411351e+00, -1.10593877e+00, -7.59594924e-02,\n",
+       "       -2.73950472e-02, -1.27256137e-01, -5.06126707e+00, -2.03193732e+01,\n",
+       "       -9.09223620e+01,  1.21340411e+00, -1.02717885e+00, -2.87269947e-01,\n",
+       "        9.27978362e-01,  1.13623256e-01,  6.86813451e-01])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The model dictionary includes the estimates under the x key. Additionally, try accessing the attributes of `mnl_model_point`, you'll find that you can't access many of the attributes generated when not using point estimation. To make the predict function work, we would have to create a list where the first element is the list of parameters, the second through the fourth are `None`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Non working example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "param_list must be a list containing 4 elements.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m~/opt/anaconda3/lib/python3.7/site-packages/pylogit/base_multinomial_cm_v2.py\u001b[0m in \u001b[0;36mcheck_type_and_size_of_param_list\u001b[0;34m(param_list, expected_length)\u001b[0m\n\u001b[1;32m    415\u001b[0m     \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 416\u001b[0;31m         \u001b[0;32massert\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mparam_list\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    417\u001b[0m         \u001b[0;32massert\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mparam_list\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0mexpected_length\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: ",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-38-ca1af7780f47>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mparam_list\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmodel_dict\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'x'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m mnl_model_point.predict(data=bike_data_long,\n\u001b[0;32m----> 4\u001b[0;31m                  param_list=param_list)\n\u001b[0m",
+      "\u001b[0;32m~/opt/anaconda3/lib/python3.7/site-packages/pylogit/base_multinomial_cm_v2.py\u001b[0m in \u001b[0;36mpredict\u001b[0;34m(self, data, param_list, return_long_probs, choice_col, num_draws, seed)\u001b[0m\n\u001b[1;32m   1863\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1864\u001b[0m         \u001b[0;31m# If param_list is passed, check the validity of its elements\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1865\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcheck_param_list_validity\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mparam_list\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1866\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1867\u001b[0m         \u001b[0;31m# Check validity of the return_long_probs and choice_col kwargs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/lib/python3.7/site-packages/pylogit/base_multinomial_cm_v2.py\u001b[0m in \u001b[0;36mcheck_param_list_validity\u001b[0;34m(self, param_list)\u001b[0m\n\u001b[1;32m   1732\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1733\u001b[0m         \u001b[0;31m# Make sure there are four elements in param_list\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1734\u001b[0;31m         \u001b[0mcheck_type_and_size_of_param_list\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mparam_list\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m4\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1735\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1736\u001b[0m         \u001b[0;31m# Make sure each element in the list is a numpy array or is None\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/lib/python3.7/site-packages/pylogit/base_multinomial_cm_v2.py\u001b[0m in \u001b[0;36mcheck_type_and_size_of_param_list\u001b[0;34m(param_list, expected_length)\u001b[0m\n\u001b[1;32m    418\u001b[0m     \u001b[0;32mexcept\u001b[0m \u001b[0mAssertionError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    419\u001b[0m         \u001b[0mmsg\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"param_list must be a list containing {} elements.\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 420\u001b[0;31m         \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmsg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mexpected_length\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    421\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    422\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: param_list must be a list containing 4 elements."
+     ]
+    }
+   ],
+   "source": [
+    "param_list = model_dict['x']\n",
+    "mnl_model_point.predict(data=bike_data_long,\n",
+    "                 param_list=param_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "param_list = [model_dict['x'], None, None, None]\n",
+    "predict_point = mnl_model_point.predict(data=bike_data_long,\n",
+    "                 param_list=param_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check whether predictions are the same between `mnl_model` and `mnl_model_point`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predict = mnl_model.predict(bike_data_long)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all(predict == predict_point)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Here is a small working example of the workaround. Doesn't look like the predict function is adaptable to each model type? My suggestion is that the check within the predict function should be on the model type and not whether the `param_list` list includes all 4 elements.

it could even be better for the estimated model to still store all results in separate attributes so that the `predict` function can be called without having to add the `param_list` parameter.