### PR TITLE
Feature/add-towncrier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,126 @@
+=========
+Changelog
+=========
+
+The format is based on [Keep-a-Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+.. towncrier release notes start
+
+Pylogit 0.2.2 (2017-12-11)
+==========================
+
+Bug fixes
+---------
+
+- Changed tqdm dependency to allow for anaconda compatibility.
+
+
+Pylogit 0.2.1 (2017-12-11)
+==========================
+
+Bug fixes
+---------
+
+- Added statsmodels and tqdm as package dependencies to fix errors with 0.2.0.
+
+
+Pylogit 0.2.0 (2017-12-10)
+==========================
+
+Added new features
+------------------
+
+- Added support for Python 3.4 - 3.6
+- Added AIC and BIC to summary tables of all models.
+- Added support for bootstrapping and calculation of bootstrap confidence intervals:
+
+  - percentile intervals,
+  - bias-corrected and accelerated (BCa) bootstrap confidence intervals, and
+  - approximate bootstrap confidence (ABC) intervals.
+
+- Changed sparse matrix creation to enable estimation of larger datasets.
+
+
+Trivial/Internal Changes
+------------------------
+
+- Refactored internal code organization and classes for estimation.
+
+
+Pylogit 0.1.2 (2016-12-04)
+==========================
+
+Added new features
+------------------
+
+- Added support to all logit-type models for parameter constraints during model estimation.
+  All models now support the use of the constrained_pos keyword argument.
+- Added new argument checks to provide user-friendly error messages.
+- Created more than 175 tests, bringing statement coverage to 99%.
+- Updated the underflow and overflow protections to make use of L’Hopital’s rule where appropriate.
+
+
+Bug fixes
+---------
+
+- Fixed bugs with the nested logit model.
+  In particular, the predict function, the BHHH approximation to the Fisher Information Matrix, and the ridge regression penalty in the log-likelihood, gradient, and hessian functions have been fixed.
+
+
+Improved Documentation
+----------------------
+
+- Added new example notebooks demonstrating prediction, mixed logit, and converting long-format datasets to wide-format.
+- Edited docstrings for clarity throughout the library.
+
+
+Trivial/Internal Changes
+------------------------
+
+- Extensively refactored codebase.
+
+
+Pylogit 0.1.1 (2016-08-30)
+==========================
+
+Improved Documentation
+----------------------
+- Added python notebook examples demonstrating how to estimate the asymmetric choice models and the nested logit model.
+- Corrected the docstrings in various places.
+- Added new datasets to the github repo.
+
+
+Pylogit 0.1.0 (2016-08-29)
+==========================
+
+Added new features
+------------------
+
+- Added asymmetric choice models.
+- Added nested logit and mixed logit models.
+- Added tests for mixed logit models.
+- Added an example notebook demonstrating how to estimate the mixed logit model.
+
+
+ Improved Documentation
+ ----------------------
+
+ - Changed documentation to numpy doctoring standard.
+
+
+Trivial/Internal Changes
+------------------------
+
+ - Made print statements compatible with python3.
+ - Fixed typos in library documentation.
+ - Internal refactoring.
+
+
+Pylogit 0.0.0 (2016-03-15)
+==========================
+
+Added new features
+------------------
+
+- Initial package release with support for the conditional logit (MNL) model.

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Where to get it
 Available from PyPi::
     pip install pylogit
 
-    https://pypi.python.org/pypi/pylogit/0.1.2
+    https://pypi.python.org/pypi/pylogit
 
 Available through Anaconda::
     conda install -c timothyb0912 pylogit
@@ -54,82 +54,9 @@ If PyLogit (or its constituent models) is useful in your research or work, pleas
 
 License
 =======
-Modified BSD (3-clause)
+Modified BSD (3-clause). See :doc:`here <./LICENSE.txt>`.
 
 Changelog
 =========
 
-0.2.2 (December 11, 2017)
--------------------------
-- Changed tqdm dependency to allow for anaconda compatibility.
-
-0.2.1 (December 11, 2017)
--------------------------
-- Added statsmodels and tqdm as package dependencies to fix errors with 0.2.0.
-
-0.2.0 (December 10, 2017)
--------------------------
-- Added support for Python 3.4 - 3.6
-
-- Added AIC and BIC to summary tables of all models.
-
-- Added support for bootstrapping and calculation of bootstrap confidence intervals:
-  - percentile intervals
-  - bias-corrected and accelerated (BCa) bootstrap confidence intervals
-  - approximate bootstrap confidence (ABC) intervals.
-
-- Changed sparse matrix creation to enable estimation of larger datasets.
-
-- Refactored internal code organization and classes for estimation.
-
-0.1.2 (December 4th, 2016)
---------------------------
-- Added support to all logit-type models for parameter constraints during model estimation. All models now support the use of the constrained_pos keyword argument.
-
-- Added new argument checks to provide user-friendly error messages.
-
-- Created more than 175 tests, bringing statement coverage to 99%.
-
-- Added new example notebooks demonstrating prediction, mixed logit, and converting long-format datasets to wide-format.
-
-- Edited docstrings for clarity throughout the library.
-
-- Extensively refactored codebase.
-
-- Updated the underflow and overflow protections to make use of L’Hopital’s rule where appropriate.
-
-- Fixed bugs with the nested logit model. In particular, the predict function, the BHHH approximation to the Fisher Information Matrix, and the ridge regression penalty in the log-likelihood, gradient, and hessian functions have been fixed.
-
-0.1.1 (August 30th, 2016)
--------------------------
-- Added python notebook examples demonstrating how to estimate the asymmetric choice models and the nested logit model.
-
-- Corrected the docstrings in various places.
-
-- Added new datasets to the github repo.
-
-0.1.0 (August 29th, 2016)
--------------------------
-- Added asymmetric choice models.
-
-- Added nested logit and mixed logit models.
-
-- Added tests for mixed logit models.
-
-- Fixed typos in library documentation.
-
-- Made print statements compatible with python3.
-
-- Changed documentation to numpy doctoring standard.
-
-- Internal refactoring.
-
-- Added an example notebook demonstrating how to estimate the mixed logit model.
-
-0.0.0 (March 15th, 2016)
--------------------------
-- Initial package release with support for the conditional logit (MNL) model.
-
-.. |Build status| image:: https://travis-ci.org/timothyb0912/pylogit.svg?branch=master
-    :target: https://travis-ci.org/timothyb0912/pylogit
-.. |Coverage| image:: https://coveralls.io/repos/github/timothyb0912/pylogit/badge.svg?branch=master
+See :doc:`here <./CHANGELOG>`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,54 @@ classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "License :: OSI Approved :: BSD License",
 ]
+
+[tool.flit.sdist]
+exclude = ["src/pylogit/newsfragments/"]
+
+[tool.towncrier]
+package = "pylogit"
+package_dir = "src/"
+filename = "CHANGELOG.rst"
+title_format = "{name} {version} ({project_date})"
+wrap = true  # Wrap text to 79 characters
+all_bullets = true
+
+    [[tool.towncrier.type]]
+    directory = "added"
+    name = "Added new features"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "changed"
+    name = "Changed existing functionality"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "deprecated"
+    name = "Marked for removal"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "removed"
+    name = "Removed from package"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "fixed"
+    name = "Bug fixes"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "security"
+    name = "Patched vulnerabilities"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "doc"
+    name = "Improved Documentation"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "trivial"
+    name = "Trivial/Internal Changes"
+    showcontent = true

--- a/requirements.in
+++ b/requirements.in
@@ -9,4 +9,5 @@ pytest
 pytest-cov
 scipy
 statsmodels
+towncrier
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 attrs==20.3.0             # via pytest
 certifi==2020.12.5        # via requests
 chardet==4.0.0            # via requests
-click==7.1.2              # via pip-tools
+click==7.1.2              # via pip-tools, towncrier
 coverage==5.3.1           # via pytest-cov
 docopt==0.6.2             # via pipreqs
 docutils==0.16            # via flit
@@ -16,7 +16,10 @@ flit==3.0.0               # via -r requirements.in
 future==0.18.2            # via -r requirements.in
 idna==2.10                # via requests
 importlib-metadata==3.3.0  # via pluggy, pytest
+incremental==17.5.0       # via towncrier
 iniconfig==1.1.1          # via pytest
+jinja2==2.11.2            # via towncrier
+markupsafe==1.1.1         # via jinja2
 mock==4.0.3               # via -r requirements.in
 numpy==1.19.4             # via -r requirements.in, pandas, patsy, scipy, statsmodels
 packaging==20.8           # via pytest
@@ -36,7 +39,8 @@ requests==2.25.1          # via flit, yarg
 scipy==1.5.4              # via -r requirements.in, statsmodels
 six==1.15.0               # via patsy, pip-tools, python-dateutil
 statsmodels==0.12.1       # via -r requirements.in
-toml==0.10.2              # via pytest
+toml==0.10.2              # via pytest, towncrier
+towncrier==19.2.0         # via -r requirements.in
 tqdm==4.55.0              # via -r requirements.in
 typing-extensions==3.7.4.3  # via importlib-metadata
 urllib3==1.26.2           # via requests

--- a/src/pylogit/newsfragments/.gitignore
+++ b/src/pylogit/newsfragments/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore


### PR DESCRIPTION
# What
This PR:
- adds towncrier to the package's development requirements,
- adds a `newsfragments` directory to the project source files to create changelog updates,
- adds towncrier configuration to the pyproject.toml page,
- removes the changelog section from the readme in favor of a relative link to the CHANGELOG document,
- adds a standalone CHANGELOG document.