### PR TITLE
Feature/add-tox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,17 @@ all_bullets = true
     directory = "trivial"
     name = "Trivial/Internal Changes"
     showcontent = true
+
+[tool.tox]
+legacy_tox_ini = """
+[tox]
+isolated_build = True
+envlist = py36, py37, py38
+requires = tox-conda
+
+[testenv]
+deps = pytest >= 3.3.0
+commands =
+    make install
+    pytest
+"""

--- a/requirements.in
+++ b/requirements.in
@@ -11,4 +11,5 @@ scipy
 statsmodels
 towncrier
 tox
+tox-conda
 tqdm

--- a/requirements.in
+++ b/requirements.in
@@ -10,4 +10,5 @@ pytest-cov
 scipy
 statsmodels
 towncrier
+tox
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,8 @@ six==1.15.0               # via patsy, pip-tools, python-dateutil, tox, virtuale
 statsmodels==0.12.1       # via -r requirements.in
 toml==0.10.2              # via pytest, towncrier, tox
 towncrier==19.2.0         # via -r requirements.in
-tox==3.20.1               # via -r requirements.in
+tox-conda==0.4.1          # via -r requirements.in
+tox==3.20.1               # via -r requirements.in, tox-conda
 tqdm==4.55.0              # via -r requirements.in
 urllib3==1.26.2           # via requests
 virtualenv==20.2.2        # via tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,31 +4,35 @@
 #
 #    pip-compile requirements.in
 #
+appdirs==1.4.4            # via virtualenv
 attrs==20.3.0             # via pytest
 certifi==2020.12.5        # via requests
 chardet==4.0.0            # via requests
 click==7.1.2              # via pip-tools, towncrier
 coverage==5.3.1           # via pytest-cov
+distlib==0.3.1            # via virtualenv
 docopt==0.6.2             # via pipreqs
 docutils==0.16            # via flit
+filelock==3.0.12          # via tox, virtualenv
 flit-core==3.0.0          # via flit
 flit==3.0.0               # via -r requirements.in
 future==0.18.2            # via -r requirements.in
 idna==2.10                # via requests
-importlib-metadata==3.3.0  # via pluggy, pytest
+importlib-metadata==2.1.1  # via pluggy, pytest, tox, virtualenv
+importlib-resources==4.1.0  # via virtualenv
 incremental==17.5.0       # via towncrier
 iniconfig==1.1.1          # via pytest
 jinja2==2.11.2            # via towncrier
 markupsafe==1.1.1         # via jinja2
 mock==4.0.3               # via -r requirements.in
 numpy==1.19.4             # via -r requirements.in, pandas, patsy, scipy, statsmodels
-packaging==20.8           # via pytest
+packaging==20.8           # via pytest, tox
 pandas==1.1.5             # via -r requirements.in, statsmodels
 patsy==0.5.1              # via statsmodels
 pip-tools==5.4.0          # via -r requirements.in
 pipreqs==0.4.10           # via -r requirements.in
-pluggy==0.13.1            # via pytest
-py==1.10.0                # via pytest
+pluggy==0.13.1            # via pytest, tox
+py==1.10.0                # via pytest, tox
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements.in
 pytest==6.2.1             # via -r requirements.in, pytest-cov
@@ -37,15 +41,16 @@ pytoml==0.1.21            # via flit, flit-core
 pytz==2020.5              # via pandas
 requests==2.25.1          # via flit, yarg
 scipy==1.5.4              # via -r requirements.in, statsmodels
-six==1.15.0               # via patsy, pip-tools, python-dateutil
+six==1.15.0               # via patsy, pip-tools, python-dateutil, tox, virtualenv
 statsmodels==0.12.1       # via -r requirements.in
-toml==0.10.2              # via pytest, towncrier
+toml==0.10.2              # via pytest, towncrier, tox
 towncrier==19.2.0         # via -r requirements.in
+tox==3.20.1               # via -r requirements.in
 tqdm==4.55.0              # via -r requirements.in
-typing-extensions==3.7.4.3  # via importlib-metadata
 urllib3==1.26.2           # via requests
+virtualenv==20.2.2        # via tox
 yarg==0.1.9               # via pipreqs
-zipp==3.4.0               # via importlib-metadata
+zipp==3.4.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/src/pylogit/newsfragments/63.trivial
+++ b/src/pylogit/newsfragments/63.trivial
@@ -1,0 +1,1 @@
+Added tox to the repository for cross-version testing of PyLogit.


### PR DESCRIPTION
# What
This PR adds `tox` to the repository for testing across python versions.
This PR also adds `tox-conda` to the repository to make `tox` use conda to create its virtual environments.