### PR TITLE
Release/1.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 .. towncrier release notes start
 
+Pylogit 1.0.1 (2020-12-27)
+==========================
+
+Trivial/Internal Changes
+------------------------
+
+- Removed setup.py from repository in favor of pyproject.toml. (#68)
+
+
 Pylogit 1.0.0 (2020-12-27)
 ==========================
 

--- a/src/pylogit/__init__.py
+++ b/src/pylogit/__init__.py
@@ -12,4 +12,4 @@ from .bootstrap import Boot
 from .choice_tools import convert_wide_to_long
 from .choice_tools import convert_long_to_wide
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/src/pylogit/newsfragments/18.trivial
+++ b/src/pylogit/newsfragments/18.trivial
@@ -1,1 +1,0 @@
-Included license file in source distribution.

--- a/src/pylogit/newsfragments/27.fixed
+++ b/src/pylogit/newsfragments/27.fixed
@@ -1,1 +1,0 @@
-Resolving import issues with the pylogit.bootstrap submodule.

--- a/src/pylogit/newsfragments/28.doc
+++ b/src/pylogit/newsfragments/28.doc
@@ -1,1 +1,0 @@
-Made example notebooks py2 and py3 compatible.

--- a/src/pylogit/newsfragments/29.fixed
+++ b/src/pylogit/newsfragments/29.fixed
@@ -1,1 +1,0 @@
-Fixed flaky tests causing continuous integration build errors.

--- a/src/pylogit/newsfragments/30.trivial
+++ b/src/pylogit/newsfragments/30.trivial
@@ -1,1 +1,0 @@
-Refactored the Hessian calculation to use less memory-intensive operations based on linear-algebra decompositions.

--- a/src/pylogit/newsfragments/33.fixed
+++ b/src/pylogit/newsfragments/33.fixed
@@ -1,1 +1,0 @@
-Fixed Hessian calculation so only the diagonal is penalized during ridge regression.

--- a/src/pylogit/newsfragments/35.trivial
+++ b/src/pylogit/newsfragments/35.trivial
@@ -1,1 +1,0 @@
-Added journal reference for the accompanying paper in the project README.

--- a/src/pylogit/newsfragments/46.trivial
+++ b/src/pylogit/newsfragments/46.trivial
@@ -1,1 +1,0 @@
-Added project logo to the repository.

--- a/src/pylogit/newsfragments/58.trivial
+++ b/src/pylogit/newsfragments/58.trivial
@@ -1,1 +1,0 @@
-Switched to pip-tools for specifying development dependencies.

--- a/src/pylogit/newsfragments/59.trivial
+++ b/src/pylogit/newsfragments/59.trivial
@@ -1,1 +1,0 @@
-Added Makefile to standardize development installation.

--- a/src/pylogit/newsfragments/60.trivial
+++ b/src/pylogit/newsfragments/60.trivial
@@ -1,1 +1,0 @@
-Switched to flit for packaging.

--- a/src/pylogit/newsfragments/61.trivial
+++ b/src/pylogit/newsfragments/61.trivial
@@ -1,1 +1,0 @@
-Added towncrier to repository.

--- a/src/pylogit/newsfragments/63.trivial
+++ b/src/pylogit/newsfragments/63.trivial
@@ -1,1 +1,0 @@
-Added tox to the repository for cross-version testing of PyLogit.

--- a/src/pylogit/newsfragments/64.trivial
+++ b/src/pylogit/newsfragments/64.trivial
@@ -1,1 +1,0 @@
-Added GitHub Actions workflow for Continuous Integration.

--- a/src/pylogit/newsfragments/65.trivial
+++ b/src/pylogit/newsfragments/65.trivial
@@ -1,1 +1,0 @@
-Converted the README.rst file to README.md.

--- a/src/pylogit/newsfragments/66.trivial
+++ b/src/pylogit/newsfragments/66.trivial
@@ -1,1 +1,0 @@
-Adding bump2version to development requirements.

--- a/src/pylogit/newsfragments/68.trivial
+++ b/src/pylogit/newsfragments/68.trivial
@@ -1,1 +1,0 @@
-Removed setup.py from repository in favor of pyproject.toml.


### PR DESCRIPTION
# What
Preppipng the 1.0.1 release: it removes setup.py.
This should allow conda skeletons to build correctly as the old and incorrect setup.py will not be present.