### PR TITLE
Update example notebook Prediction with PyLogit from pd.Series.sort() to pd.Series.sort_values()

### DIFF
--- a/examples/notebooks/Prediction with PyLogit.ipynb
+++ b/examples/notebooks/Prediction with PyLogit.ipynb
@@ -19,19 +19,8 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/timothyb0912/anaconda/lib/python2.7/site-packages/IPython/html.py:14: ShimWarning: The `IPython.html` package has been deprecated. You should import from `notebook` instead. `IPython.html.widgets` has moved to `ipywidgets`.\n",
-      "  \"`IPython.html.widgets` has moved to `ipywidgets`.\", ShimWarning)\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# For recording the model specification \n",
     "from collections import OrderedDict\n",
@@ -63,9 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load the dataset\n",
@@ -91,14 +78,25 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -434,9 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# NOTE: - Specification and variable names must be ordered dictionaries.\n",
@@ -497,9 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The 'alt_id_column' is the name of a column to be created in the long-format data\n",
@@ -526,26 +520,30 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Log-likelihood at zero: -4,906.5129\n",
-      "Initial Log-likelihood: -4,906.5129\n",
-      "Estimation Time: 0.15 seconds.\n",
-      "Final log-likelihood: -3,668.2772\n"
+      "Initial Log-likelihood: -4,906.5129\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/timothyb0912/anaconda/lib/python2.7/site-packages/scipy/optimize/_minimize.py:382: RuntimeWarning: Method BFGS does not use Hessian information (hess).\n",
-      "  RuntimeWarning)\n"
+      "/home/danph/anaconda3/envs/dev/lib/python3.8/site-packages/scipy/optimize/_minimize.py:522: RuntimeWarning: Method BFGS does not use Hessian information (hess).\n",
+      "  warn('Method %s does not use Hessian information (hess).' % method,\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Estimation Time for Point Estimation: 0.22 seconds.\n",
+      "Final log-likelihood: -3,668.2772\n"
      ]
     }
    ],
@@ -573,17 +571,29 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Log-likelihood at zero: -4,906.5129\n",
-      "Initial Log-likelihood: -3,668.2772\n",
-      "Estimation Time: 0.42 seconds.\n",
+      "Initial Log-likelihood: -3,668.2772\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/danph/anaconda3/envs/dev/lib/python3.8/site-packages/scipy/optimize/_minimize.py:522: RuntimeWarning: Method BFGS does not use Hessian information (hess).\n",
+      "  warn('Method %s does not use Hessian information (hess).' % method,\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Estimation Time for Point Estimation: 0.85 seconds.\n",
       "Final log-likelihood: -3,533.2248\n"
      ]
     }
@@ -659,17 +669,29 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Log-likelihood at zero: -4,906.5129\n",
-      "Initial Log-likelihood: -3,668.2772\n",
-      "Estimation Time: 0.31 seconds.\n",
+      "Initial Log-likelihood: -3,668.2772\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/danph/anaconda3/envs/dev/lib/python3.8/site-packages/scipy/optimize/_minimize.py:522: RuntimeWarning: Method BFGS does not use Hessian information (hess).\n",
+      "  warn('Method %s does not use Hessian information (hess).' % method,\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Estimation Time for Point Estimation: 0.61 seconds.\n",
       "Final log-likelihood: -3,511.3976\n"
      ]
     }
@@ -731,17 +753,29 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Log-likelihood at zero: -4,906.5129\n",
-      "Initial Log-likelihood: -3,668.2772\n",
-      "Estimation Time: 0.50 seconds.\n",
+      "Initial Log-likelihood: -3,668.2772\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/danph/anaconda3/envs/dev/lib/python3.8/site-packages/scipy/optimize/_minimize.py:522: RuntimeWarning: Method BFGS does not use Hessian information (hess).\n",
+      "  warn('Method %s does not use Hessian information (hess).' % method,\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Estimation Time for Point Estimation: 0.88 seconds.\n",
       "Final log-likelihood: -3,505.9938\n"
      ]
     }
@@ -799,17 +833,29 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Log-likelihood at zero: -4,906.5129\n",
-      "Initial Log-likelihood: -4,249.4904\n",
-      "Estimation Time: 0.41 seconds.\n",
+      "Initial Log-likelihood: -4,249.4904\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/danph/anaconda3/envs/dev/lib/python3.8/site-packages/scipy/optimize/_minimize.py:522: RuntimeWarning: Method BFGS does not use Hessian information (hess).\n",
+      "  warn('Method %s does not use Hessian information (hess).' % method,\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Estimation Time for Point Estimation: 0.26 seconds.\n",
       "Final log-likelihood: -3,680.1916\n"
      ]
     }
@@ -870,18 +916,42 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Log-likelihood at zero: -4,594.2735\n",
-      "Initial Log-likelihood: -3,666.8367\n",
-      "Estimation Time: 0.49 seconds.\n",
+      "Initial Log-likelihood: -3,666.8367\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/danph/anaconda3/envs/dev/lib/python3.8/site-packages/scipy/optimize/_minimize.py:522: RuntimeWarning: Method BFGS does not use Hessian information (hess).\n",
+      "  warn('Method %s does not use Hessian information (hess).' % method,\n",
+      "/home/danph/anaconda3/envs/dev/lib/python3.8/site-packages/pylogit/nested_choice_calcs.py:135: RuntimeWarning: overflow encountered in exp\n",
+      "  exp_scaled_index = np.exp(scaled_index)\n",
+      "/home/danph/anaconda3/envs/dev/lib/python3.8/site-packages/pylogit/nested_choice_calcs.py:135: RuntimeWarning: overflow encountered in exp\n",
+      "  exp_scaled_index = np.exp(scaled_index)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Estimation Time for Point Estimation: 40.59 seconds.\n",
       "Final log-likelihood: -3,575.2522\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/danph/anaconda3/envs/dev/lib/python3.8/site-packages/pylogit/base_multinomial_cm_v2.py:1259: RuntimeWarning: invalid value encountered in sqrt\n",
+      "  self._store_inferential_results(np.sqrt(np.diag(self.robust_cov)),\n"
      ]
     },
     {
@@ -899,69 +969,69 @@
        "  <th>Method:</th>                <td>MLE</td>        <th>  Df Model:          </th>     <td>16</td>    \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Date:</th>           <td>Thu, 17 Nov 2016</td>  <th>  Pseudo R-squ.:     </th>    <td>0.222</td>  \n",
+       "  <th>Date:</th>           <td>Fri, 15 Jan 2021</td>  <th>  Pseudo R-squ.:     </th>    <td>0.222</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Time:</th>               <td>23:52:23</td>      <th>  Pseudo R-bar-squ.: </th>    <td>0.218</td>  \n",
+       "  <th>Time:</th>               <td>19:46:43</td>      <th>  Pseudo R-bar-squ.: </th>    <td>0.218</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>converged:</th>            <td>False</td>       <th>  Log-Likelihood:    </th> <td>-3,575.252</td>\n",
+       "  <th>AIC:</th>                <td>7,182.504</td>     <th>  Log-Likelihood:    </th> <td>-3,575.252</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th> </th>                       <td> </td>         <th>  LL-Null:           </th> <td>-4,594.273</td>\n",
+       "  <th>BIC:</th>                <td>7,286.019</td>     <th>  LL-Null:           </th> <td>-4,594.273</td>\n",
        "</tr>\n",
        "</table>\n",
        "<table class=\"simpletable\">\n",
        "<tr>\n",
-       "                                 <td></td>                                   <th>coef</th>     <th>std err</th>      <th>z</th>      <th>P>|z|</th> <th>[95.0% Conf. Int.]</th> \n",
+       "                                 <td></td>                                   <th>coef</th>     <th>std err</th>      <th>z</th>      <th>P>|z|</th>  <th>[0.025</th>    <th>0.975]</th>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Future Modes</th>                                                   <td>   40.0000</td> <td>      nan</td> <td>      nan</td> <td>   nan</td> <td>      nan       nan</td>\n",
+       "  <th>Future Modes</th>                                                   <td>   40.0000</td> <td>      nan</td> <td>      nan</td> <td>   nan</td> <td>      nan</td> <td>      nan</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Existing Modes</th>                                                 <td>   -0.4513</td> <td>    0.121</td> <td>   -3.728</td> <td> 0.000</td> <td>   -0.689    -0.214</td>\n",
+       "  <th>Existing Modes</th>                                                 <td>   -0.4513</td> <td>    0.121</td> <td>   -3.728</td> <td> 0.000</td> <td>   -0.689</td> <td>   -0.214</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>ASC Train</th>                                                      <td>   -0.6825</td> <td>    0.115</td> <td>   -5.924</td> <td> 0.000</td> <td>   -0.908    -0.457</td>\n",
+       "  <th>ASC Train</th>                                                      <td>   -0.6825</td> <td>    0.115</td> <td>   -5.924</td> <td> 0.000</td> <td>   -0.908</td> <td>   -0.457</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>ASC Swissmetro</th>                                                 <td>   -0.1837</td> <td>    0.113</td> <td>   -1.619</td> <td> 0.105</td> <td>   -0.406     0.039</td>\n",
+       "  <th>ASC Swissmetro</th>                                                 <td>   -0.1837</td> <td>    0.113</td> <td>   -1.619</td> <td> 0.105</td> <td>   -0.406</td> <td>    0.039</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Time, units:hrs (Train and Swissmetro)</th>                  <td>   -0.4452</td> <td>    0.026</td> <td>  -17.129</td> <td> 0.000</td> <td>   -0.496    -0.394</td>\n",
+       "  <th>Travel Time, units:hrs (Train and Swissmetro)</th>                  <td>   -0.4452</td> <td>    0.026</td> <td>  -17.129</td> <td> 0.000</td> <td>   -0.496</td> <td>   -0.394</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Time, units:hrs (Car)</th>                                   <td>   -0.3540</td> <td>    0.025</td> <td>  -14.339</td> <td> 0.000</td> <td>   -0.402    -0.306</td>\n",
+       "  <th>Travel Time, units:hrs (Car)</th>                                   <td>   -0.3540</td> <td>    0.025</td> <td>  -14.339</td> <td> 0.000</td> <td>   -0.402</td> <td>   -0.306</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)</th>      <td>   -0.1932</td> <td>    0.055</td> <td>   -3.505</td> <td> 0.000</td> <td>   -0.301    -0.085</td>\n",
+       "  <th>Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)</th>      <td>   -0.1932</td> <td>    0.055</td> <td>   -3.505</td> <td> 0.000</td> <td>   -0.301</td> <td>   -0.085</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)</th> <td>   -0.1713</td> <td>    0.049</td> <td>   -3.474</td> <td> 0.001</td> <td>   -0.268    -0.075</td>\n",
+       "  <th>Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)</th> <td>   -0.1713</td> <td>    0.049</td> <td>   -3.474</td> <td> 0.001</td> <td>   -0.268</td> <td>   -0.075</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Cost, units: 0.01 CHF (Car)</th>                             <td>   -0.5397</td> <td>    0.062</td> <td>   -8.742</td> <td> 0.000</td> <td>   -0.661    -0.419</td>\n",
+       "  <th>Travel Cost, units: 0.01 CHF (Car)</th>                             <td>   -0.5397</td> <td>    0.062</td> <td>   -8.742</td> <td> 0.000</td> <td>   -0.661</td> <td>   -0.419</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Headway, units:hrs, (Train)</th>                                    <td>   -0.2679</td> <td>    0.050</td> <td>   -5.375</td> <td> 0.000</td> <td>   -0.366    -0.170</td>\n",
+       "  <th>Headway, units:hrs, (Train)</th>                                    <td>   -0.2679</td> <td>    0.050</td> <td>   -5.375</td> <td> 0.000</td> <td>   -0.366</td> <td>   -0.170</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Headway, units:hrs, (Swissmetro)</th>                               <td>   -0.4575</td> <td>    0.225</td> <td>   -2.031</td> <td> 0.042</td> <td>   -0.899    -0.016</td>\n",
+       "  <th>Headway, units:hrs, (Swissmetro)</th>                               <td>   -0.4575</td> <td>    0.225</td> <td>   -2.031</td> <td> 0.042</td> <td>   -0.899</td> <td>   -0.016</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Airline Seat Configuration, base=No (Swissmetro)</th>               <td>   -0.3986</td> <td>    0.103</td> <td>   -3.887</td> <td> 0.000</td> <td>   -0.600    -0.198</td>\n",
+       "  <th>Airline Seat Configuration, base=No (Swissmetro)</th>               <td>   -0.3986</td> <td>    0.103</td> <td>   -3.887</td> <td> 0.000</td> <td>   -0.600</td> <td>   -0.198</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Surveyed on a Train, base=No, (Train and Swissmetro)</th>           <td>    1.4522</td> <td>    0.112</td> <td>   12.994</td> <td> 0.000</td> <td>    1.233     1.671</td>\n",
+       "  <th>Surveyed on a Train, base=No, (Train and Swissmetro)</th>           <td>    1.4522</td> <td>    0.112</td> <td>   12.994</td> <td> 0.000</td> <td>    1.233</td> <td>    1.671</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>First Class == False, (Swissmetro)</th>                             <td>    0.2518</td> <td>    0.061</td> <td>    4.101</td> <td> 0.000</td> <td>    0.131     0.372</td>\n",
+       "  <th>First Class == False, (Swissmetro)</th>                             <td>    0.2518</td> <td>    0.061</td> <td>    4.101</td> <td> 0.000</td> <td>    0.131</td> <td>    0.372</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Number of Luggage Pieces == 1, (Car)</th>                           <td>    0.1595</td> <td>    0.058</td> <td>    2.759</td> <td> 0.006</td> <td>    0.046     0.273</td>\n",
+       "  <th>Number of Luggage Pieces == 1, (Car)</th>                           <td>    0.1595</td> <td>    0.058</td> <td>    2.759</td> <td> 0.006</td> <td>    0.046</td> <td>    0.273</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Number of Luggage Pieces > 1, (Car)</th>                            <td>    0.7496</td> <td>    0.167</td> <td>    4.495</td> <td> 0.000</td> <td>    0.423     1.076</td>\n",
+       "  <th>Number of Luggage Pieces > 1, (Car)</th>                            <td>    0.7496</td> <td>    0.167</td> <td>    4.495</td> <td> 0.000</td> <td>    0.423</td> <td>    1.076</td>\n",
        "</tr>\n",
        "</table>"
       ],
@@ -973,29 +1043,29 @@
        "Dep. Variable:                 CHOICE   No. Observations:                4,768\n",
        "Model:             Nested Logit Model   Df Residuals:                    4,752\n",
        "Method:                           MLE   Df Model:                           16\n",
-       "Date:                Thu, 17 Nov 2016   Pseudo R-squ.:                   0.222\n",
-       "Time:                        23:52:23   Pseudo R-bar-squ.:               0.218\n",
-       "converged:                      False   Log-Likelihood:             -3,575.252\n",
-       "                                        LL-Null:                    -4,594.273\n",
+       "Date:                Fri, 15 Jan 2021   Pseudo R-squ.:                   0.222\n",
+       "Time:                        19:46:43   Pseudo R-bar-squ.:               0.218\n",
+       "AIC:                        7,182.504   Log-Likelihood:             -3,575.252\n",
+       "BIC:                        7,286.019   LL-Null:                    -4,594.273\n",
        "==================================================================================================================================\n",
-       "                                                                     coef    std err          z      P>|z|      [95.0% Conf. Int.]\n",
+       "                                                                     coef    std err          z      P>|z|      [0.025      0.975]\n",
        "----------------------------------------------------------------------------------------------------------------------------------\n",
-       "Future Modes                                                      40.0000        nan        nan        nan           nan       nan\n",
-       "Existing Modes                                                    -0.4513      0.121     -3.728      0.000        -0.689    -0.214\n",
-       "ASC Train                                                         -0.6825      0.115     -5.924      0.000        -0.908    -0.457\n",
-       "ASC Swissmetro                                                    -0.1837      0.113     -1.619      0.105        -0.406     0.039\n",
-       "Travel Time, units:hrs (Train and Swissmetro)                     -0.4452      0.026    -17.129      0.000        -0.496    -0.394\n",
-       "Travel Time, units:hrs (Car)                                      -0.3540      0.025    -14.339      0.000        -0.402    -0.306\n",
-       "Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)         -0.1932      0.055     -3.505      0.000        -0.301    -0.085\n",
-       "Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)    -0.1713      0.049     -3.474      0.001        -0.268    -0.075\n",
-       "Travel Cost, units: 0.01 CHF (Car)                                -0.5397      0.062     -8.742      0.000        -0.661    -0.419\n",
-       "Headway, units:hrs, (Train)                                       -0.2679      0.050     -5.375      0.000        -0.366    -0.170\n",
-       "Headway, units:hrs, (Swissmetro)                                  -0.4575      0.225     -2.031      0.042        -0.899    -0.016\n",
-       "Airline Seat Configuration, base=No (Swissmetro)                  -0.3986      0.103     -3.887      0.000        -0.600    -0.198\n",
-       "Surveyed on a Train, base=No, (Train and Swissmetro)               1.4522      0.112     12.994      0.000         1.233     1.671\n",
-       "First Class == False, (Swissmetro)                                 0.2518      0.061      4.101      0.000         0.131     0.372\n",
-       "Number of Luggage Pieces == 1, (Car)                               0.1595      0.058      2.759      0.006         0.046     0.273\n",
-       "Number of Luggage Pieces > 1, (Car)                                0.7496      0.167      4.495      0.000         0.423     1.076\n",
+       "Future Modes                                                      40.0000        nan        nan        nan         nan         nan\n",
+       "Existing Modes                                                    -0.4513      0.121     -3.728      0.000      -0.689      -0.214\n",
+       "ASC Train                                                         -0.6825      0.115     -5.924      0.000      -0.908      -0.457\n",
+       "ASC Swissmetro                                                    -0.1837      0.113     -1.619      0.105      -0.406       0.039\n",
+       "Travel Time, units:hrs (Train and Swissmetro)                     -0.4452      0.026    -17.129      0.000      -0.496      -0.394\n",
+       "Travel Time, units:hrs (Car)                                      -0.3540      0.025    -14.339      0.000      -0.402      -0.306\n",
+       "Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)         -0.1932      0.055     -3.505      0.000      -0.301      -0.085\n",
+       "Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)    -0.1713      0.049     -3.474      0.001      -0.268      -0.075\n",
+       "Travel Cost, units: 0.01 CHF (Car)                                -0.5397      0.062     -8.742      0.000      -0.661      -0.419\n",
+       "Headway, units:hrs, (Train)                                       -0.2679      0.050     -5.375      0.000      -0.366      -0.170\n",
+       "Headway, units:hrs, (Swissmetro)                                  -0.4575      0.225     -2.031      0.042      -0.899      -0.016\n",
+       "Airline Seat Configuration, base=No (Swissmetro)                  -0.3986      0.103     -3.887      0.000      -0.600      -0.198\n",
+       "Surveyed on a Train, base=No, (Train and Swissmetro)               1.4522      0.112     12.994      0.000       1.233       1.671\n",
+       "First Class == False, (Swissmetro)                                 0.2518      0.061      4.101      0.000       0.131       0.372\n",
+       "Number of Luggage Pieces == 1, (Car)                               0.1595      0.058      2.759      0.006       0.046       0.273\n",
+       "Number of Luggage Pieces > 1, (Car)                                0.7496      0.167      4.495      0.000       0.423       1.076\n",
        "==================================================================================================================================\n",
        "\"\"\""
       ]
@@ -1058,18 +1128,38 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Log-likelihood at zero: -4,906.5129\n",
-      "Initial Log-likelihood: -3,668.2772\n",
-      "Estimation Time: 3.25 minutes.\n",
-      "Final log-likelihood: -2,824.8372\n"
+      "Initial Log-likelihood: -3,668.2772\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/danph/anaconda3/envs/dev/lib/python3.8/site-packages/scipy/optimize/_minimize.py:522: RuntimeWarning: Method BFGS does not use Hessian information (hess).\n",
+      "  warn('Method %s does not use Hessian information (hess).' % method,\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Estimation Time for Point Estimation: 4.71 minutes.\n",
+      "Final log-likelihood: -2,821.5398\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/danph/anaconda3/envs/dev/lib/python3.8/site-packages/pylogit/base_multinomial_cm_v2.py:1259: RuntimeWarning: invalid value encountered in sqrt\n",
+      "  self._store_inferential_results(np.sqrt(np.diag(self.robust_cov)),\n"
      ]
     },
     {
@@ -1087,78 +1177,78 @@
        "  <th>Method:</th>               <td>MLE</td>        <th>  Df Model:          </th>     <td>19</td>    \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Date:</th>          <td>Thu, 17 Nov 2016</td>  <th>  Pseudo R-squ.:     </th>    <td>0.424</td>  \n",
+       "  <th>Date:</th>          <td>Fri, 15 Jan 2021</td>  <th>  Pseudo R-squ.:     </th>    <td>0.425</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Time:</th>              <td>23:55:44</td>      <th>  Pseudo R-bar-squ.: </th>    <td>0.420</td>  \n",
+       "  <th>Time:</th>              <td>19:51:39</td>      <th>  Pseudo R-bar-squ.: </th>    <td>0.421</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>converged:</th>           <td>False</td>       <th>  Log-Likelihood:    </th> <td>-2,824.837</td>\n",
+       "  <th>AIC:</th>               <td>5,681.080</td>     <th>  Log-Likelihood:    </th> <td>-2,821.540</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th> </th>                      <td> </td>         <th>  LL-Null:           </th> <td>-4,906.513</td>\n",
+       "  <th>BIC:</th>               <td>5,804.004</td>     <th>  LL-Null:           </th> <td>-4,906.513</td>\n",
        "</tr>\n",
        "</table>\n",
        "<table class=\"simpletable\">\n",
        "<tr>\n",
-       "                                    <td></td>                                      <th>coef</th>     <th>std err</th>      <th>z</th>      <th>P>|z|</th> <th>[95.0% Conf. Int.]</th> \n",
+       "                                    <td></td>                                      <th>coef</th>     <th>std err</th>      <th>z</th>      <th>P>|z|</th>  <th>[0.025</th>    <th>0.975]</th>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>ASC Train</th>                                                            <td>   -2.8480</td> <td>    0.460</td> <td>   -6.190</td> <td> 0.000</td> <td>   -3.750    -1.946</td>\n",
+       "  <th>ASC Train</th>                                                            <td>   -2.7267</td> <td>    0.456</td> <td>   -5.980</td> <td> 0.000</td> <td>   -3.620</td> <td>   -1.833</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>ASC Swissmetro</th>                                                       <td>   -2.9022</td> <td>    0.398</td> <td>   -7.299</td> <td> 0.000</td> <td>   -3.682    -2.123</td>\n",
+       "  <th>ASC Swissmetro</th>                                                       <td>   -2.8100</td> <td>    0.390</td> <td>   -7.201</td> <td> 0.000</td> <td>   -3.575</td> <td>   -2.045</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Time, units:hrs (Train and Swissmetro)</th>                        <td>   -3.0662</td> <td>    0.178</td> <td>  -17.262</td> <td> 0.000</td> <td>   -3.414    -2.718</td>\n",
+       "  <th>Travel Time, units:hrs (Train and Swissmetro)</th>                        <td>   -3.1728</td> <td>    0.183</td> <td>  -17.304</td> <td> 0.000</td> <td>   -3.532</td> <td>   -2.813</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Time, units:hrs (Car)</th>                                         <td>   -3.7078</td> <td>    0.169</td> <td>  -21.924</td> <td> 0.000</td> <td>   -4.039    -3.376</td>\n",
+       "  <th>Travel Time, units:hrs (Car)</th>                                         <td>   -3.6756</td> <td>    0.169</td> <td>  -21.750</td> <td> 0.000</td> <td>   -4.007</td> <td>   -3.344</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)</th>            <td>   -5.3458</td> <td>    0.634</td> <td>   -8.435</td> <td> 0.000</td> <td>   -6.588    -4.104</td>\n",
+       "  <th>Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)</th>            <td>   -5.4490</td> <td>    0.639</td> <td>   -8.527</td> <td> 0.000</td> <td>   -6.702</td> <td>   -4.197</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)</th>       <td>   -2.7045</td> <td>    0.330</td> <td>   -8.195</td> <td> 0.000</td> <td>   -3.351    -2.058</td>\n",
+       "  <th>Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)</th>       <td>   -2.7122</td> <td>    0.335</td> <td>   -8.090</td> <td> 0.000</td> <td>   -3.369</td> <td>   -2.055</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Cost, units: 0.01 CHF (Car)</th>                                   <td>   -2.8815</td> <td>    0.333</td> <td>   -8.664</td> <td> 0.000</td> <td>   -3.533    -2.230</td>\n",
+       "  <th>Travel Cost, units: 0.01 CHF (Car)</th>                                   <td>   -2.9506</td> <td>    0.333</td> <td>   -8.850</td> <td> 0.000</td> <td>   -3.604</td> <td>   -2.297</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Headway, units:hrs, (Train)</th>                                          <td>   -0.5237</td> <td>    0.117</td> <td>   -4.488</td> <td> 0.000</td> <td>   -0.752    -0.295</td>\n",
+       "  <th>Headway, units:hrs, (Train)</th>                                          <td>   -0.5247</td> <td>    0.116</td> <td>   -4.514</td> <td> 0.000</td> <td>   -0.753</td> <td>   -0.297</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Headway, units:hrs, (Swissmetro)</th>                                     <td>   -0.9966</td> <td>    0.356</td> <td>   -2.799</td> <td> 0.005</td> <td>   -1.694    -0.299</td>\n",
+       "  <th>Headway, units:hrs, (Swissmetro)</th>                                     <td>   -1.0121</td> <td>    0.355</td> <td>   -2.851</td> <td> 0.004</td> <td>   -1.708</td> <td>   -0.316</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Airline Seat Configuration, base=No (Swissmetro)</th>                     <td>   -0.5921</td> <td>    0.185</td> <td>   -3.195</td> <td> 0.001</td> <td>   -0.955    -0.229</td>\n",
+       "  <th>Airline Seat Configuration, base=No (Swissmetro)</th>                     <td>   -0.5789</td> <td>    0.185</td> <td>   -3.133</td> <td> 0.002</td> <td>   -0.941</td> <td>   -0.217</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Surveyed on a Train, base=No, (Train and Swissmetro)</th>                 <td>    5.8038</td> <td>    0.452</td> <td>   12.852</td> <td> 0.000</td> <td>    4.919     6.689</td>\n",
+       "  <th>Surveyed on a Train, base=No, (Train and Swissmetro)</th>                 <td>    5.7223</td> <td>    0.437</td> <td>   13.103</td> <td> 0.000</td> <td>    4.866</td> <td>    6.578</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>First Class == False, (Swissmetro)</th>                                   <td>    0.9976</td> <td>    0.183</td> <td>    5.441</td> <td> 0.000</td> <td>    0.638     1.357</td>\n",
+       "  <th>First Class == False, (Swissmetro)</th>                                   <td>    1.0509</td> <td>    0.184</td> <td>    5.708</td> <td> 0.000</td> <td>    0.690</td> <td>    1.412</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Number of Luggage Pieces == 1, (Car)</th>                                 <td>    1.1681</td> <td>    0.334</td> <td>    3.503</td> <td> 0.000</td> <td>    0.514     1.822</td>\n",
+       "  <th>Number of Luggage Pieces == 1, (Car)</th>                                 <td>    1.0612</td> <td>    0.331</td> <td>    3.204</td> <td> 0.001</td> <td>    0.412</td> <td>    1.710</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Number of Luggage Pieces > 1, (Car)</th>                                  <td>    2.7793</td> <td>    1.030</td> <td>    2.699</td> <td> 0.007</td> <td>    0.761     4.798</td>\n",
+       "  <th>Number of Luggage Pieces > 1, (Car)</th>                                  <td>    2.9543</td> <td>    0.943</td> <td>    3.132</td> <td> 0.002</td> <td>    1.105</td> <td>    4.803</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Sigma Travel Time, units:hrs (Train and Swissmetro)</th>                  <td>    2.2175</td> <td>    0.113</td> <td>   19.692</td> <td> 0.000</td> <td>    1.997     2.438</td>\n",
+       "  <th>Sigma Travel Time, units:hrs (Train and Swissmetro)</th>                  <td>    2.2726</td> <td>    0.120</td> <td>   18.982</td> <td> 0.000</td> <td>    2.038</td> <td>    2.507</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Sigma Travel Time, units:hrs (Car)</th>                                   <td>    1.4464</td> <td>    0.108</td> <td>   13.426</td> <td> 0.000</td> <td>    1.235     1.658</td>\n",
+       "  <th>Sigma Travel Time, units:hrs (Car)</th>                                   <td>    1.4247</td> <td>    0.098</td> <td>   14.464</td> <td> 0.000</td> <td>    1.232</td> <td>    1.618</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Sigma Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)</th>      <td>    2.4709</td> <td>    0.512</td> <td>    4.826</td> <td> 0.000</td> <td>    1.467     3.474</td>\n",
+       "  <th>Sigma Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)</th>      <td>   -2.0159</td> <td>    0.598</td> <td>   -3.374</td> <td> 0.001</td> <td>   -3.187</td> <td>   -0.845</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Sigma Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)</th> <td>    1.5809</td> <td>    0.276</td> <td>    5.720</td> <td> 0.000</td> <td>    1.039     2.123</td>\n",
+       "  <th>Sigma Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)</th> <td>    1.4788</td> <td>    0.298</td> <td>    4.969</td> <td> 0.000</td> <td>    0.896</td> <td>    2.062</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Sigma Travel Cost, units: 0.01 CHF (Car)</th>                             <td>   -1.8658</td> <td>    0.315</td> <td>   -5.930</td> <td> 0.000</td> <td>   -2.482    -1.249</td>\n",
+       "  <th>Sigma Travel Cost, units: 0.01 CHF (Car)</th>                             <td>   -1.8856</td> <td>    0.301</td> <td>   -6.266</td> <td> 0.000</td> <td>   -2.475</td> <td>   -1.296</td>\n",
        "</tr>\n",
        "</table>"
       ],
@@ -1170,32 +1260,32 @@
        "Dep. Variable:                 CHOICE   No. Observations:                4,768\n",
        "Model:              Mixed Logit Model   Df Residuals:                    4,749\n",
        "Method:                           MLE   Df Model:                           19\n",
-       "Date:                Thu, 17 Nov 2016   Pseudo R-squ.:                   0.424\n",
-       "Time:                        23:55:44   Pseudo R-bar-squ.:               0.420\n",
-       "converged:                      False   Log-Likelihood:             -2,824.837\n",
-       "                                        LL-Null:                    -4,906.513\n",
+       "Date:                Fri, 15 Jan 2021   Pseudo R-squ.:                   0.425\n",
+       "Time:                        19:51:39   Pseudo R-bar-squ.:               0.421\n",
+       "AIC:                        5,681.080   Log-Likelihood:             -2,821.540\n",
+       "BIC:                        5,804.004   LL-Null:                    -4,906.513\n",
        "========================================================================================================================================\n",
-       "                                                                           coef    std err          z      P>|z|      [95.0% Conf. Int.]\n",
+       "                                                                           coef    std err          z      P>|z|      [0.025      0.975]\n",
        "----------------------------------------------------------------------------------------------------------------------------------------\n",
-       "ASC Train                                                               -2.8480      0.460     -6.190      0.000        -3.750    -1.946\n",
-       "ASC Swissmetro                                                          -2.9022      0.398     -7.299      0.000        -3.682    -2.123\n",
-       "Travel Time, units:hrs (Train and Swissmetro)                           -3.0662      0.178    -17.262      0.000        -3.414    -2.718\n",
-       "Travel Time, units:hrs (Car)                                            -3.7078      0.169    -21.924      0.000        -4.039    -3.376\n",
-       "Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)               -5.3458      0.634     -8.435      0.000        -6.588    -4.104\n",
-       "Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)          -2.7045      0.330     -8.195      0.000        -3.351    -2.058\n",
-       "Travel Cost, units: 0.01 CHF (Car)                                      -2.8815      0.333     -8.664      0.000        -3.533    -2.230\n",
-       "Headway, units:hrs, (Train)                                             -0.5237      0.117     -4.488      0.000        -0.752    -0.295\n",
-       "Headway, units:hrs, (Swissmetro)                                        -0.9966      0.356     -2.799      0.005        -1.694    -0.299\n",
-       "Airline Seat Configuration, base=No (Swissmetro)                        -0.5921      0.185     -3.195      0.001        -0.955    -0.229\n",
-       "Surveyed on a Train, base=No, (Train and Swissmetro)                     5.8038      0.452     12.852      0.000         4.919     6.689\n",
-       "First Class == False, (Swissmetro)                                       0.9976      0.183      5.441      0.000         0.638     1.357\n",
-       "Number of Luggage Pieces == 1, (Car)                                     1.1681      0.334      3.503      0.000         0.514     1.822\n",
-       "Number of Luggage Pieces > 1, (Car)                                      2.7793      1.030      2.699      0.007         0.761     4.798\n",
-       "Sigma Travel Time, units:hrs (Train and Swissmetro)                      2.2175      0.113     19.692      0.000         1.997     2.438\n",
-       "Sigma Travel Time, units:hrs (Car)                                       1.4464      0.108     13.426      0.000         1.235     1.658\n",
-       "Sigma Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)          2.4709      0.512      4.826      0.000         1.467     3.474\n",
-       "Sigma Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)     1.5809      0.276      5.720      0.000         1.039     2.123\n",
-       "Sigma Travel Cost, units: 0.01 CHF (Car)                                -1.8658      0.315     -5.930      0.000        -2.482    -1.249\n",
+       "ASC Train                                                               -2.7267      0.456     -5.980      0.000      -3.620      -1.833\n",
+       "ASC Swissmetro                                                          -2.8100      0.390     -7.201      0.000      -3.575      -2.045\n",
+       "Travel Time, units:hrs (Train and Swissmetro)                           -3.1728      0.183    -17.304      0.000      -3.532      -2.813\n",
+       "Travel Time, units:hrs (Car)                                            -3.6756      0.169    -21.750      0.000      -4.007      -3.344\n",
+       "Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)               -5.4490      0.639     -8.527      0.000      -6.702      -4.197\n",
+       "Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)          -2.7122      0.335     -8.090      0.000      -3.369      -2.055\n",
+       "Travel Cost, units: 0.01 CHF (Car)                                      -2.9506      0.333     -8.850      0.000      -3.604      -2.297\n",
+       "Headway, units:hrs, (Train)                                             -0.5247      0.116     -4.514      0.000      -0.753      -0.297\n",
+       "Headway, units:hrs, (Swissmetro)                                        -1.0121      0.355     -2.851      0.004      -1.708      -0.316\n",
+       "Airline Seat Configuration, base=No (Swissmetro)                        -0.5789      0.185     -3.133      0.002      -0.941      -0.217\n",
+       "Surveyed on a Train, base=No, (Train and Swissmetro)                     5.7223      0.437     13.103      0.000       4.866       6.578\n",
+       "First Class == False, (Swissmetro)                                       1.0509      0.184      5.708      0.000       0.690       1.412\n",
+       "Number of Luggage Pieces == 1, (Car)                                     1.0612      0.331      3.204      0.001       0.412       1.710\n",
+       "Number of Luggage Pieces > 1, (Car)                                      2.9543      0.943      3.132      0.002       1.105       4.803\n",
+       "Sigma Travel Time, units:hrs (Train and Swissmetro)                      2.2726      0.120     18.982      0.000       2.038       2.507\n",
+       "Sigma Travel Time, units:hrs (Car)                                       1.4247      0.098     14.464      0.000       1.232       1.618\n",
+       "Sigma Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)         -2.0159      0.598     -3.374      0.001      -3.187      -0.845\n",
+       "Sigma Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)     1.4788      0.298      4.969      0.000       0.896       2.062\n",
+       "Sigma Travel Cost, units: 0.01 CHF (Car)                                -1.8856      0.301     -6.266      0.000      -2.475      -1.296\n",
        "========================================================================================================================================\n",
        "\"\"\""
       ]
@@ -1248,9 +1338,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create an ordered dictionary mapping shortened model\n",
@@ -1319,9 +1407,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Calculate and store the predictions for the mixed logit \n",
@@ -1363,26 +1449,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 17,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Mixed         -1534.343235\n",
+       "Mixed         -1537.366205\n",
        "Clog          -1516.255638\n",
-       "MNL           -1495.346433\n",
+       "MNL           -1495.346434\n",
        "Asym          -1462.023258\n",
        "Nested        -1461.652262\n",
        "Scobit        -1451.833670\n",
        "Uneven        -1447.384942\n",
-       "Mixed_Panel    -947.548620\n",
+       "Mixed_Panel    -948.328382\n",
        "Name: Log-likelihood of Predictions, dtype: float64"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1390,7 +1474,7 @@
    "source": [
     "# Look at the predicted log-likelihoods of the various models\n",
     "pd.Series(prediction_log_likelihoods,\n",
-    "          name=\"Log-likelihood of Predictions\").sort(inplace=False)"
+    "          name=\"Log-likelihood of Predictions\").sort_values(inplace=False)"
    ]
   },
   {
@@ -1417,10 +1501,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 18,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1437,72 +1519,72 @@
        "  <th>Method:</th>                      <td>MLE</td>              <th>  Df Model:          </th>     <td>17</td>    \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Date:</th>                 <td>Thu, 17 Nov 2016</td>        <th>  Pseudo R-squ.:     </th>    <td>0.284</td>  \n",
+       "  <th>Date:</th>                 <td>Fri, 15 Jan 2021</td>        <th>  Pseudo R-squ.:     </th>    <td>0.284</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Time:</th>                     <td>23:55:54</td>            <th>  Pseudo R-bar-squ.: </th>    <td>0.281</td>  \n",
+       "  <th>Time:</th>                     <td>20:00:36</td>            <th>  Pseudo R-bar-squ.: </th>    <td>0.281</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>converged:</th>                  <td>False</td>             <th>  Log-Likelihood:    </th> <td>-3,511.398</td>\n",
+       "  <th>AIC:</th>                      <td>7,056.795</td>           <th>  Log-Likelihood:    </th> <td>-3,511.398</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th> </th>                             <td> </td>               <th>  LL-Null:           </th> <td>-4,906.513</td>\n",
+       "  <th>BIC:</th>                      <td>7,166.780</td>           <th>  LL-Null:           </th> <td>-4,906.513</td>\n",
        "</tr>\n",
        "</table>\n",
        "<table class=\"simpletable\">\n",
        "<tr>\n",
-       "                                 <td></td>                                   <th>coef</th>     <th>std err</th>      <th>z</th>      <th>P>|z|</th> <th>[95.0% Conf. Int.]</th> \n",
+       "                                 <td></td>                                   <th>coef</th>     <th>std err</th>      <th>z</th>      <th>P>|z|</th>  <th>[0.025</th>    <th>0.975]</th>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>shape_train</th>                                                    <td>    1.0271</td> <td>    0.141</td> <td>    7.274</td> <td> 0.000</td> <td>    0.750     1.304</td>\n",
+       "  <th>shape_train</th>                                                    <td>    1.0271</td> <td>    0.141</td> <td>    7.274</td> <td> 0.000</td> <td>    0.750</td> <td>    1.304</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>shape_swiss_metro</th>                                              <td>    0.1120</td> <td>    0.232</td> <td>    0.482</td> <td> 0.630</td> <td>   -0.343     0.567</td>\n",
+       "  <th>shape_swiss_metro</th>                                              <td>    0.1120</td> <td>    0.232</td> <td>    0.482</td> <td> 0.630</td> <td>   -0.343</td> <td>    0.567</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>shape_car</th>                                                      <td>   -0.4157</td> <td>    0.561</td> <td>   -0.741</td> <td> 0.458</td> <td>   -1.515     0.683</td>\n",
+       "  <th>shape_car</th>                                                      <td>   -0.4157</td> <td>    0.561</td> <td>   -0.741</td> <td> 0.458</td> <td>   -1.515</td> <td>    0.683</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>ASC Train</th>                                                      <td>   -1.1675</td> <td>    0.240</td> <td>   -4.873</td> <td> 0.000</td> <td>   -1.637    -0.698</td>\n",
+       "  <th>ASC Train</th>                                                      <td>   -1.1675</td> <td>    0.240</td> <td>   -4.873</td> <td> 0.000</td> <td>   -1.637</td> <td>   -0.698</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>ASC Swissmetro</th>                                                 <td>   -0.6523</td> <td>    0.234</td> <td>   -2.785</td> <td> 0.005</td> <td>   -1.111    -0.193</td>\n",
+       "  <th>ASC Swissmetro</th>                                                 <td>   -0.6523</td> <td>    0.234</td> <td>   -2.785</td> <td> 0.005</td> <td>   -1.111</td> <td>   -0.193</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Time, units:hrs (Train and Swissmetro)</th>                  <td>   -0.3399</td> <td>    0.051</td> <td>   -6.621</td> <td> 0.000</td> <td>   -0.441    -0.239</td>\n",
+       "  <th>Travel Time, units:hrs (Train and Swissmetro)</th>                  <td>   -0.3399</td> <td>    0.051</td> <td>   -6.621</td> <td> 0.000</td> <td>   -0.441</td> <td>   -0.239</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Time, units:hrs (Car)</th>                                   <td>   -0.9527</td> <td>    0.591</td> <td>   -1.611</td> <td> 0.107</td> <td>   -2.112     0.207</td>\n",
+       "  <th>Travel Time, units:hrs (Car)</th>                                   <td>   -0.9527</td> <td>    0.591</td> <td>   -1.611</td> <td> 0.107</td> <td>   -2.112</td> <td>    0.207</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)</th>      <td>   -0.2552</td> <td>    0.071</td> <td>   -3.573</td> <td> 0.000</td> <td>   -0.395    -0.115</td>\n",
+       "  <th>Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)</th>      <td>   -0.2552</td> <td>    0.071</td> <td>   -3.573</td> <td> 0.000</td> <td>   -0.395</td> <td>   -0.115</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)</th> <td>   -0.2218</td> <td>    0.061</td> <td>   -3.648</td> <td> 0.000</td> <td>   -0.341    -0.103</td>\n",
+       "  <th>Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)</th> <td>   -0.2218</td> <td>    0.061</td> <td>   -3.648</td> <td> 0.000</td> <td>   -0.341</td> <td>   -0.103</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Travel Cost, units: 0.01 CHF (Car)</th>                             <td>   -0.5969</td> <td>    0.404</td> <td>   -1.479</td> <td> 0.139</td> <td>   -1.388     0.194</td>\n",
+       "  <th>Travel Cost, units: 0.01 CHF (Car)</th>                             <td>   -0.5969</td> <td>    0.404</td> <td>   -1.479</td> <td> 0.139</td> <td>   -1.388</td> <td>    0.194</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Headway, units:hrs, (Train)</th>                                    <td>   -0.2833</td> <td>    0.056</td> <td>   -5.086</td> <td> 0.000</td> <td>   -0.392    -0.174</td>\n",
+       "  <th>Headway, units:hrs, (Train)</th>                                    <td>   -0.2833</td> <td>    0.056</td> <td>   -5.086</td> <td> 0.000</td> <td>   -0.392</td> <td>   -0.174</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Headway, units:hrs, (Swissmetro)</th>                               <td>   -0.4631</td> <td>    0.220</td> <td>   -2.102</td> <td> 0.036</td> <td>   -0.895    -0.031</td>\n",
+       "  <th>Headway, units:hrs, (Swissmetro)</th>                               <td>   -0.4631</td> <td>    0.220</td> <td>   -2.102</td> <td> 0.036</td> <td>   -0.895</td> <td>   -0.031</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Airline Seat Configuration, base=No (Swissmetro)</th>               <td>   -0.1097</td> <td>    0.108</td> <td>   -1.015</td> <td> 0.310</td> <td>   -0.321     0.102</td>\n",
+       "  <th>Airline Seat Configuration, base=No (Swissmetro)</th>               <td>   -0.1097</td> <td>    0.108</td> <td>   -1.015</td> <td> 0.310</td> <td>   -0.321</td> <td>    0.102</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Surveyed on a Train, base=No, (Train and Swissmetro)</th>           <td>    2.0947</td> <td>    0.238</td> <td>    8.809</td> <td> 0.000</td> <td>    1.629     2.561</td>\n",
+       "  <th>Surveyed on a Train, base=No, (Train and Swissmetro)</th>           <td>    2.0947</td> <td>    0.238</td> <td>    8.809</td> <td> 0.000</td> <td>    1.629</td> <td>    2.561</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>First Class == False, (Swissmetro)</th>                             <td>    0.1665</td> <td>    0.064</td> <td>    2.598</td> <td> 0.009</td> <td>    0.041     0.292</td>\n",
+       "  <th>First Class == False, (Swissmetro)</th>                             <td>    0.1665</td> <td>    0.064</td> <td>    2.598</td> <td> 0.009</td> <td>    0.041</td> <td>    0.292</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Number of Luggage Pieces == 1, (Car)</th>                           <td>    0.5712</td> <td>    0.365</td> <td>    1.565</td> <td> 0.118</td> <td>   -0.144     1.286</td>\n",
+       "  <th>Number of Luggage Pieces == 1, (Car)</th>                           <td>    0.5712</td> <td>    0.365</td> <td>    1.565</td> <td> 0.118</td> <td>   -0.144</td> <td>    1.286</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Number of Luggage Pieces > 1, (Car)</th>                            <td>    2.1772</td> <td>    0.967</td> <td>    2.251</td> <td> 0.024</td> <td>    0.281     4.073</td>\n",
+       "  <th>Number of Luggage Pieces > 1, (Car)</th>                            <td>    2.1772</td> <td>    0.967</td> <td>    2.251</td> <td> 0.024</td> <td>    0.281</td> <td>    4.073</td>\n",
        "</tr>\n",
        "</table>"
       ],
@@ -1514,35 +1596,35 @@
        "Dep. Variable:                             CHOICE   No. Observations:                4,768\n",
        "Model:             Multinomial Uneven Logit Model   Df Residuals:                    4,751\n",
        "Method:                                       MLE   Df Model:                           17\n",
-       "Date:                            Thu, 17 Nov 2016   Pseudo R-squ.:                   0.284\n",
-       "Time:                                    23:55:54   Pseudo R-bar-squ.:               0.281\n",
-       "converged:                                  False   Log-Likelihood:             -3,511.398\n",
-       "                                                    LL-Null:                    -4,906.513\n",
+       "Date:                            Fri, 15 Jan 2021   Pseudo R-squ.:                   0.284\n",
+       "Time:                                    20:00:36   Pseudo R-bar-squ.:               0.281\n",
+       "AIC:                                    7,056.795   Log-Likelihood:             -3,511.398\n",
+       "BIC:                                    7,166.780   LL-Null:                    -4,906.513\n",
        "==================================================================================================================================\n",
-       "                                                                     coef    std err          z      P>|z|      [95.0% Conf. Int.]\n",
+       "                                                                     coef    std err          z      P>|z|      [0.025      0.975]\n",
        "----------------------------------------------------------------------------------------------------------------------------------\n",
-       "shape_train                                                        1.0271      0.141      7.274      0.000         0.750     1.304\n",
-       "shape_swiss_metro                                                  0.1120      0.232      0.482      0.630        -0.343     0.567\n",
-       "shape_car                                                         -0.4157      0.561     -0.741      0.458        -1.515     0.683\n",
-       "ASC Train                                                         -1.1675      0.240     -4.873      0.000        -1.637    -0.698\n",
-       "ASC Swissmetro                                                    -0.6523      0.234     -2.785      0.005        -1.111    -0.193\n",
-       "Travel Time, units:hrs (Train and Swissmetro)                     -0.3399      0.051     -6.621      0.000        -0.441    -0.239\n",
-       "Travel Time, units:hrs (Car)                                      -0.9527      0.591     -1.611      0.107        -2.112     0.207\n",
-       "Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)         -0.2552      0.071     -3.573      0.000        -0.395    -0.115\n",
-       "Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)    -0.2218      0.061     -3.648      0.000        -0.341    -0.103\n",
-       "Travel Cost, units: 0.01 CHF (Car)                                -0.5969      0.404     -1.479      0.139        -1.388     0.194\n",
-       "Headway, units:hrs, (Train)                                       -0.2833      0.056     -5.086      0.000        -0.392    -0.174\n",
-       "Headway, units:hrs, (Swissmetro)                                  -0.4631      0.220     -2.102      0.036        -0.895    -0.031\n",
-       "Airline Seat Configuration, base=No (Swissmetro)                  -0.1097      0.108     -1.015      0.310        -0.321     0.102\n",
-       "Surveyed on a Train, base=No, (Train and Swissmetro)               2.0947      0.238      8.809      0.000         1.629     2.561\n",
-       "First Class == False, (Swissmetro)                                 0.1665      0.064      2.598      0.009         0.041     0.292\n",
-       "Number of Luggage Pieces == 1, (Car)                               0.5712      0.365      1.565      0.118        -0.144     1.286\n",
-       "Number of Luggage Pieces > 1, (Car)                                2.1772      0.967      2.251      0.024         0.281     4.073\n",
+       "shape_train                                                        1.0271      0.141      7.274      0.000       0.750       1.304\n",
+       "shape_swiss_metro                                                  0.1120      0.232      0.482      0.630      -0.343       0.567\n",
+       "shape_car                                                         -0.4157      0.561     -0.741      0.458      -1.515       0.683\n",
+       "ASC Train                                                         -1.1675      0.240     -4.873      0.000      -1.637      -0.698\n",
+       "ASC Swissmetro                                                    -0.6523      0.234     -2.785      0.005      -1.111      -0.193\n",
+       "Travel Time, units:hrs (Train and Swissmetro)                     -0.3399      0.051     -6.621      0.000      -0.441      -0.239\n",
+       "Travel Time, units:hrs (Car)                                      -0.9527      0.591     -1.611      0.107      -2.112       0.207\n",
+       "Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Train)         -0.2552      0.071     -3.573      0.000      -0.395      -0.115\n",
+       "Travel Cost * (Annual Pass == 0), units: 0.01 CHF (Swissmetro)    -0.2218      0.061     -3.648      0.000      -0.341      -0.103\n",
+       "Travel Cost, units: 0.01 CHF (Car)                                -0.5969      0.404     -1.479      0.139      -1.388       0.194\n",
+       "Headway, units:hrs, (Train)                                       -0.2833      0.056     -5.086      0.000      -0.392      -0.174\n",
+       "Headway, units:hrs, (Swissmetro)                                  -0.4631      0.220     -2.102      0.036      -0.895      -0.031\n",
+       "Airline Seat Configuration, base=No (Swissmetro)                  -0.1097      0.108     -1.015      0.310      -0.321       0.102\n",
+       "Surveyed on a Train, base=No, (Train and Swissmetro)               2.0947      0.238      8.809      0.000       1.629       2.561\n",
+       "First Class == False, (Swissmetro)                                 0.1665      0.064      2.598      0.009       0.041       0.292\n",
+       "Number of Luggage Pieces == 1, (Car)                               0.5712      0.365      1.565      0.118      -0.144       1.286\n",
+       "Number of Luggage Pieces > 1, (Car)                                2.1772      0.967      2.251      0.024       0.281       4.073\n",
        "==================================================================================================================================\n",
        "\"\"\""
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1560,10 +1642,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 19,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create an array of 100 travel cost parameters between\n",
@@ -1595,21 +1675,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 20,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "array([[ 1.02708012,  1.02708012,  1.02708012,  1.02708012],\n",
        "       [ 0.11201881,  0.11201881,  0.11201881,  0.11201881],\n",
-       "       [-0.41569969, -0.41569969, -0.41569969, -0.41569969],\n",
+       "       [-0.41569968, -0.41569968, -0.41569968, -0.41569968],\n",
        "       [-1.16746396, -1.16746396, -1.16746396, -1.16746396],\n",
        "       [-0.65231139, -0.65231139, -0.65231139, -0.65231139],\n",
        "       [-0.33994783, -0.33994783, -0.33994783, -0.33994783],\n",
-       "       [-0.95266145, -0.95266145, -0.95266145, -0.95266145],\n",
+       "       [-0.95266144, -0.95266144, -0.95266144, -0.95266144],\n",
        "       [-0.25521738, -0.25521738, -0.25521738, -0.25521738],\n",
        "       [-0.221815  , -0.221815  , -0.221815  , -0.221815  ],\n",
        "       [-1.        , -0.99193809, -0.98387617, -0.97581426],\n",
@@ -1619,10 +1697,10 @@
        "       [ 2.09467556,  2.09467556,  2.09467556,  2.09467556],\n",
        "       [ 0.16650129,  0.16650129,  0.16650129,  0.16650129],\n",
        "       [ 0.57115182,  0.57115182,  0.57115182,  0.57115182],\n",
-       "       [ 2.17715196,  2.17715196,  2.17715196,  2.17715196]])"
+       "       [ 2.17715195,  2.17715195,  2.17715195,  2.17715195]])"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1650,10 +1728,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 21,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Since this is not a nested logit we have no nest parameters\n",
@@ -1692,19 +1768,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 22,
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAEZCAYAAACw69OmAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xd4FWX2wPHvTQ8hBUjoJdRDB+mCgCA2FMtiQUUBxbKu\num6zrL9F17r2tcsqoi4WFlFRERUFpCgdQj/U0EsoIZCQfn9/zIRESEISktyU83mePMmde2fm3Ddz\n75m3zDser9eLMcYYc7b8fB2AMcaYqsESijHGmFJhCcUYY0ypsIRijDGmVFhCMcYYUyosoRhjjCkV\nAb4OoCoRkVhgtaqGl9H2RwPDVXWYiLwDfAJsLe4+S2s7BWz7ONBeVXeczXYK2f4UoJX7sAuwBsgC\nDqvqBWWxT3e/5wOvqWqnfJ7zB/4I3IDzmQoCvgbGqWp6Cfc3Dlipql+dsjwW2AKsyrPYA7yiqhNL\nsq+yICKRwBeqOvgst3MR8A6wDxioqqkl3E4U8DgwEMgGvMDrqvreWcb3Ps7n5sVTlp/8HLifsTdV\ndUV+nzcRuROIUtVnRWQsEKiqb51NXL5iCaWSUtXb4eQXjM+3k0eZXtikqtfm/C0i2cD5qnq4LPdZ\nBG8BkcBgVT0mIjWAj4B3gVtKuM3BwNoCnktR1XNyHohIQ2CNiCxV1dUl3F9pqwX0LIXtjAD+o6pP\nlXQDIhIC/Az8FzhHVbNFpCnwk4hwlknFS/7HfN5lQ4C3If/Pm6qOz/Pa84CK8j8sNkso5cQ9Y3sD\n56zaC8wA/q6qWSIyFPgXzpn2SpwDsF9hZ/kiMgd4DViWZ1k7YDrwJ1WdJiJ93e2G4ZyVPaaq0wvZ\njr+IvAX0AqKAv6nq5yISCLyE8yWXBSxy93FcRPq762cDS8mnGdU9y3xBVTu7j6NwztBa4JzV3wmk\nA6nAnaq6/owFmn+ZvA/Udrf7NTARp8zDgIY4ZXs9MAoYpqrD3PXaAj8CTYC2wL+BOoA/8GphZ/4i\n0hy4EaivqscBVDVFRO4CznVfU9j//p/AVe77PwSMBoYD3YHnRSRTVacV9r5VdY+IbAJai8hWnATX\n2i2LY8CNqrrR/V8fct/jmzj/82eBYKABMFNVx7pfdrOAn9z3EAj8Fef/1Bbn/3yDqnoLOcYmAqEi\nshzoAUh+5erW/F4Bjrvb6JVTqxORvwFXAidEJAJ4BHiZ/I/DeGAh0Bl4+JQyux5IUtUX8pTZDhG5\nDqc2iYhcDjzsPq4LfKCq4/KJr6eqZpzyL/AU8K/xiMhTOMfeJBEZBTzH6Z/bx9xy+QkYBlwgIieA\n+4B7VXWm+7p3cGo1rxawP5+zPpTy8yqQ4DaZ9MD5cvmriNQBPgRucs86ZwONirC935wZiUhH4Cvg\nNjeZ1ALeA0aqanecD+ZbItKkkO2EAD+4r/8LzsEP8H9AfZwPaxec4+Z5N9FMwflQd8P5Ego9NVBV\n/QGoKSLd3UU3AN8ASThfEBerai/gP0C/Irz3gniBEFXtqKoPA2OBiaraF6eZrDkwFPgYOE9E6rrr\njcEpKz/gM+AhVe0BnI/zP+pdyD67AWtzkkme97xfVb90Hxb0v2+C01TWQ1V7Aj/gfKG+gfOl/dcz\nJRMAETnXfX+LgEtwmv/OVVUBlgD35Cmfw6rawd3HfcA/VLUP0AG4QkRyaj6xwDRV7YjzRfcKTm2h\nA9Af6O0eYxPJ/xgbDZxwj4szlWsHYISqds3bRKiqz+Mc0y+p6oPAP8jnOMzz3laravt8yqwHsODU\nclPVFaq6SEQ8wJ+BW9z/w7nAwyJSO5/4Tk0mhfGq6iPAHpzP92IKqdG4x8tXwMuq+ibOicFYADeh\nXgG8X4z9lztLKOXnEuB1APdD8zZwKc6Hc11OU4WqfojzRVtUXpxEMAtYoaqz3eXn4px1ThORFTg1\nl2ycD2NBzVLpqvqF+3cczplaTuxvq2qWqnpxzrAuBTq568x2Y/8U54w4PxNwvmTA+QJ/V1WzcRLS\nryLyGnAU54v9bMzP8/eDwCH3TPdtnDPFmu6X/2fAzW7/x01ufIJTu3nPLbM5OGXblYLLLIszf44K\n+t/vwinnFSLyPKf3mRR05hsqIivcn9XA0zi1kN2qOhX4UETuFZFXcL68w/KsOy/P36OA2iLyME6N\npQZQ030uQ1W/cf/eAixQ1eOqmobzBVkb5xirz+nHWKdTYm9DweUKsFNVdxbwXvMq6DjM773llYVT\nK8qXu61hQE+37+pFN/6ccissvuwClvu5+y0qTz5/fwBcKCLROMfo16panO+GcmdNXuXHj98eNP44\nTQmZnP7FkY1TXX4H5+wKnC+h/DokPThfdlfiVKuvdpOCP7DePfsEQEQaAAnAyAJizHv25c0TV0Gx\nezk99swCtj0R54vzXSBSVecCqOrNItIeuBAnAdyG0wRUUsl5/v7UjXUyzpddkzzxvotTI1qPk9C3\ni0gnIPGU/om6OInu3AL2twRoJyI5iSpnvUbAeOAaCig/94tsoFtzuxB4WURmq+r97usKSmIn8saY\nl4j8Hrgd58v2I5wmrtg8L8lbk5oPrAC+A/6H09SZE+epgwny+7/6UfAx1jjP6/wpvFx/U7srREHH\nYY6CtrMQ+MOpC0XkCpw+i8dwmkOn4iSl93COwZx9FRbfQZzmqrzbDcdJmEcKWe9U3lP/VtVEdxDK\nzTi1+ruLsT2fsBpK+fke96AWkWDgDpwmjgVAG/fLDBEZjtN/ka2qt6vqOe7PeAo+Y01T1V+BW4G3\nRaQezoeotdvHgduUsQmn1lKS2O8SkQAR8XPfxw84nYceEbnU3ccVOJ2xp1HVPThNMuNxRu0gItEi\nsgOnGeYVnCaNziWIryAXAY+r6hT3cW/ckyhVXYRTnuNwEguAAqkicpMbX1OcUWTdCtqBqu7G+eJ+\nz/0iyWmeeBM4qM6opHz/9yLSWUTWABtU9V84fQw57z8Tt32/BO/5fbffZyNOM0nes3OPG0ctnH6a\nh9ymlsY4zWb5nckXdNwVdoxl5tlWscu1gP0XdByeyVQgUkT+5q6HiLTAqYmsw6lBheM0/03HqdUF\nU0itJo8ZwHVuIsVtPrsf+FlVU9zXFOV/mfMeT31tTtOkR1WXFiEen7KEUvrCROTYKT8dcA6Kum4T\nxSqcM+OnVPUIztnHhyKyDOcLIRNIyWfbhY4oUdWfcc7KJ6hqAk7n7vMishKn+jzSrboXZWRK3sdP\n4gzbXInzAfQH/qiqmThnck+4TRlXA/sLKZt3cJo5PnDjPehu+ycRWQo8Q26b8V1uDa0wZ3oPfwe+\nEJElOO3Rc4CWp8TTHPjSjScdp6Y3VkTicM7c/89N1gXtD5wzx3XAL245LMT5whzrPl/Q/34VTs1g\nqRvjaOBP7jpfAy+IyM1FfN85XgDudOP4Eafzt1We53OOlSM45b3c3fdDODWWVpx+fOR7vLj/v4KO\nsT3uttfhNB2VpFxPfb/5HodnWBe332MITl/IajeGz4AnVPV9nGbHb4AN7mdwGM4Iu/zK4tRtz8EZ\n2PCtW+brgXY4n+kcXwKfisiFBbyvvPuYAdwnIg+6218FHMYdJVbReWz6et9yz2r/D2d0zAkR6YbT\nVlqUjnljTBUmIi1xBuq00RJeg1OeyrUPRUTCcEbYROG00Y5SZ8jj1TijNXI6vh7NaWMXkVbA55o7\n5DTa3UYIzlnQGFU9UZ7vozSpc91COrBERDJw+jGu83FYxhgfE5HHcfrD7qsMyQTKuYYiIn8EwlX1\nSXdM9jmqer+IPAksV9XPT3n9zTjNBY1UtaG77FVgqap+6FYL01T13+X2JowxxuSrXPtQ3I7Xp92H\nzcgdBdENuFVE5orIC+5QTnDaDgfy207BfjhtsOC0Nw4p26iNMcYURZk1eYnIbTijHfIararLRGQW\nTgfZRe7ymTjz/sSLyNvAXcAb7ogLRCTvNiJwhhuCM5wvsozegjHGmGIos4SiqhNwLhbL77nB4mSJ\n6TgjKSaqaqL79DSckSMFScJJKgk4Q/0SC3ktXq/X6/EUNOrRGGNMAYr9xVnenfIPAbtUdRLOBWg5\nF0vFiUhfd0z/EJxpJwqyAGf6jA9wrpKdW9g+PR4PCQkFXbxdvcTEhFtZuKwscllZ5LKyyBUTU/yJ\nx8v7Svn3gA/c5jB/nCk4wBmv/7k4E6Ktxb3wLY+8IweedLdxO04t5cayDdkYY0xRVIfrULx2xuGo\nqmdfmVnZHDmWxpFjaSQeT+NocjrHUjJIPpFBSlomKamZpKVnkp6ZTUZmNpnZXvw8HjIys/D38+Dv\n74e/n4cAfw8hQQGEBPkTGhxAaFAA4WGBRIQFEVkjiIiaQdSJCCEyLIiq1IxaVY+LkrCyyBUTE16x\nm7yMKSmv18uhpFR2JSSz71AK+w4ns+/wCQ4ePcGRpLQi3YQlKMCPwAA//P39CPD3w+v1kpGZTVZ2\nJlnZXjKznIRzJoEBfkRHhhAdGUr92jVoGF2DRtE1aRhdgxohgWdc35iqyhKKqXC8Xi8Hjpxg694k\n4vceI35fErsSjnMi7beTt3qAqPBgWjeJok5EMLXCQ6gVHkxkWBDhNQKpGRpIjZBAagQHEBTo95ta\nRUFnolnZ2aSmZ3HCrdkcS8ngaHIaSckZJB5P41BSKgcTUzl49AR7D6Wweuuh36xfJyKE2PrhxDYI\nJ7Z+BM0bhFuSMdWGJRTjc1nZ2ezYfxzdkcjGnYls3n2U4ydyJz72eKB+7Rp0bF6TxjFhNIwOo37t\nGtStFUpgQFHm7ys6fz8/wkL8CAsJPOOA9JTUDPYeSmHPwWT2HEpmd0Iy2/cfY9nGBJZtTHBiBxrX\nrUmbxlG0aRqFNIkiIqwkcz4aU/FZQjE+kZB4gjXbDrN222HWbz/CibTc2dHrRITQPrYWLRtGEtsg\nnKZ1wwkOKt3EURpqhATSslEkLRvlZh6v18uRY2nE7zvGtr1JbN51lK17k9h54Dg/Ld8FQNN6NenY\nvA6dWtSmZaNIAvxtjlZTNVhCMeUi2+tly+6jrNh0kFVbDrHnYO5tS6IjQ+jZNgZpWgtpEkXtiBAf\nRnp2PB4PtSNCqB0RQrc2MQBkZGYTvy+JjTsTWRd/hE27Etmx/zjfLtxOaLA/nVtG061NDB2b1yY0\n2D6SpvKyUV7VSHmPYMnO9qI7E1my4QArNiZwNNm5Z1NQgB/tmtWic8s6dGhem7q1apRbTDl69uxE\ndraXZcvWlPu+09Kz2LDjCGu2HWblpoMcSnLm/Qvw99Ahtja9O9TjnFYx5VYrs5FNuawsctkoL+Nz\nXq+X+H3H+HXtPpasP3AyidQMDaR/5wac0yaG9s1qERRY8ZqwyktwkD9dWkXTpVU0Nw5pzc4Dx1m+\nMYHlGxOI23KIuC2HCAr0o1vrGPp0qE/H5rXx86s6w5RN1WUJxZSKo8fTWLBmHwtW72XvIefeYDVD\nAxnYtSG92talTdMo/P2sr+BUHo+HpvXCaVovnKv6t2D3wWQWrdvPonX7WLhuPwvX7adWeDDndWpA\n/84NiI4K9XXIxhTIEoopsWyvlzVbD/Pzyt3EbT5EttdLgL8fPdrWpW9H58zaOpyLp1F0GL8b0IKr\n+zdn654kFqzZx6J1+/j6l3i++SWe9rG1GNy9MV1aRlutxVQ4llBMsR0/kcG8VXuYs2I3CYlO+3/T\nejXp37khfTrUc4bcmrPi8XhOjiC7flArluoBfo7bw9r4I6yNP0J0ZAgXdG9M/84N7DoXU2FYQjFF\ntudgMjOX7uTXNftIz8wmKMCP/p0bcP45jWjeIMLX4VVZwUH+9OvUgH6dGjjDj5ft4te1+5g8azNf\nztvGgC4NubhXk0o9Os5UDTbKqxopyQgWr9fLxp2JfLdoB3FbnKvCoyNDGNytMf27NKi0tZHKPprn\n+IkM5sbt4adluzhyLA1/Pw992tfjkj7NaBQdVqxtVfayKE1WFrlslJcpNV6vl1VbDvHNr/Fs2Z0E\nQKtGkVzcqwnntI6x9nsfqxkayNA+zbioZxMWrt3PjEXbnUERa/bRo21druwXS6OYmr4O01QzllDM\nb2R7vazYeJCvF2xjx4HjAHRtFc3QPs1o1dhujlnRBPj7cV7nBvTtVJ+4TQf5+pd4lm44wLINB+jZ\nri5X9GtOw2LWWIwpKUsoBnBqJCs3HWTafCeReDzQu309LuvTjMZ17Uy3ovPzeDinTQxdW0cTt/kQ\nX87fyuL1B1iy/gB9O9Xn6v4trI/FlDlLKIZ18YeZ+vNWtu1NwgP06VCPYX1jaVDHzmwrG4/HQ9fW\n0XRpVYcVmw7yxbytLFi9j8XrDzCkR2Mu69PMRoWZMmMJpRrbvu8Yn83ZzNr4IwD0kBiu6t/Cmkiq\nAI/HQ7c2MXRtFc0va/bxxbytzFi4g7kr93Dlec0Z1K2RXWhqSp0llGrocFIqU3/eysK1+/ACHZrX\nZvjAFsTWrz5Df2NjY302l1d58vPzcF7nBvRqV5eflu3im1+38/GPm/h55R5uGNKa9rG1fR2iqUIs\noVQjqWmZfDlvK98t2kF6ZjZN6tbkukGt6NDcvlSquqBAfy7t04x+nRrw+dytzIvbwwufrqRbmxju\nvrYrVlcxpcGuQ6kGvF4vSzYcYMqcLRw6mkpkWBDDB7akb6f6+FWhe6MXhy9nG64Itu87xkc/bmTz\nrqMEB/lzRd9YLuzZpNpPlWPXoeQqyXUollCquN0Jx/lo5kY27EgkMMCPi3s1YWifZoQEVe/KaXVP\nKOCcaCxcu5//zdnM0ePpNI4J45ZL2tKqUfUdHm4JJZdd2GhOSkvP4qsF2/hhyU6ysr10bRXNH67r\nin92tq9DMxWEx+Ph3I71GdS7GW9/tpK5cXt5+r/LGHROI645v6Xd7MsUmx0xVdDKzQf56AflUFIa\n0ZEh3HRhG7q0iiamTpidfZnThNcIYvSl7ejbsQEffq/MXrGbVVsOMXpoWzpYp70pBmvyqkKOHk/j\n4x83sWTDAfz9PFzSuymX940l2L2ZlVXnc1lZ5MpbFhmZ2Xz9yza+/XUH2V4vA7o04LpBrakRUj3O\nPe24yFXhm7xEJAz4GIgC0oFRqrpHRK4Gngd2ui8dp6rzROR5oJ8b539U9V0RiXa3EQLsAcao6ony\nfB8Vjdfr5Zc1+/jkx02kpGXSslEEoy9pa3M5mWILDPDjdwNa0r1NXSZMX8/cuL2s3XaYsZe3R5rW\n8nV4poIr7yEdY4ElqjoQmAQ84C7vDjygqoPcn3kiMghooap9gfOAB0UkChgHTFLVAcAK4M5yfg8V\nyuGkVP49ZRUTpq8ny+vlpgvb8PDI7pZMzFlpVj+ccaN7MKxvLIePpfHcxyuYMnszGZnWB2cKVq41\nFFV9RURyklgz4Ij7dzegq4jcDywGHgR+wUkYOfyBDJway5PushnA08C/yzj0CienVvLxjxs5kZZF\nh9hajLq0LdGRdotYUzoC/P24ekALOreswztfr2PGoh2s2XaYO4a1txMWk68ySygichtw/ymLR6vq\nMhGZBXQALnKXzwS+UNV4EXkbuEtV3wDSRCQQ+AAYr6rJIhIBHHXXOw6ccYxjTEx4KbyjiuPIsVTe\nmBLHorX7CA32555ru3BR72Z4inBNSVUri7NhZZGrsLKIiQmnS7v6vDttDT8s2s4THyzljqs7FfmY\nq2zsuCi5MksoqjoBmFDAc4NFRIDpQCtgoqomuk9PA4YDiEgtYAowW1WfdZ9PAiKABCAcSOQMqlIn\n28rNB5n47XqOpWTQtmkUtw5tR3RUKAcPHj/jutbhmMvKIldRy2LEoJa0aRTBxG/X8/qUOBav2cuo\nS9pWqeHFdlzkKkliLe9O+YeAXao6CUgGMt2n4kSkr6ruBoYAS0UkFPgJeF5VP8mzmQXAUJxay6XA\n3HJ7Az6UlpHF5FmbmbNiNwH+Hq4f3IoLezaptle6n63qMpdXaevWJoZm9cIZ/9VaFq8/wLa9Sdx1\nZUe7BbQBynnYsIjUxUkEITh9Ig+q6q8iciFOv8gJYC3wR+BenA74lXk2Mdp9zQc4tZME4MYzjPKq\n9MOGdx44ztvT1rD3UAqNY8K4Y1iHEt2jxM6+ctmV8rlKclxkZmUzbf42pv+6nQB/Dzdd2IYBXRpW\n+iYw+4zksqlX8ldpE4rX62XW8t1MnrWZzKxshnRvzLWDWhIY4F+i7dmHJZcllFxnc1ys2XqI8V+t\nJTk1k/M6NWDkRW0ICizZ8VkR2GckV4W/DsUUXUpqBhO/3cCyjQnUDA3k1ss60rVVtK/DMuY3Orao\nw6Oje/LGl2uYv3ovOw4c4w9XdyImykYbVkfVe2rRCmrb3iQem7iEZRsTkCZR/PPWXpZMTIUVHRXK\n30d2Y0CXhuzYf5zH31/CuvjDvg7L+IAllArE6/Uye/kunpm0jENHUxnWN5a/3tCVWuHBvg7NmEIF\nBvgz+tK2jL60LanpWbw0OY4fl+6kGjSpmzysyauCSEvP4oPvN7Bw7X5qhgZyxxXt6di8jq/DqrLi\n4+OtrbwMDOjSkAZ1avDG56v5+MdN7Eo4zsiLpNrfZ6W6sP9yBXDgSApP/XcpC9fup0XDCB4d3dOS\niam0WjeOYtzonjSrF87cuL0898kKklLSfR2WKQeWUHxs1ZZDPP7+UnYlJDPonEY8eGM36kSG+Dos\nY85K7YgQHhrZjV7t6rJ511Ge+nApew8l+zosU8YsofiI1+tl+q/xvDIljvTMbMYMbcvNFwuBAfYv\nMVVDcKA/d17RgWF9Y0lITOXp/y5jw/YjZ17RVFr27eUDaRlZjP9qLVN/3kpUeDAPj+xG/84NfR2W\nMaXO4/Fw9YAW3HZZO1LTs3hx8koWrN7r67BMGbFO+XJ2OCmV16auZvv+Y7RqHMkfrupIZE0bxWWq\ntn6dGlA7IoQ3Pl/NhOnrOXwsjcvPrZqTS1ZnVkMpR1v3JPHEh0vZvv8Y/Ts34IEbzrFk4iOxsbF0\n797R12FUK+2a1eLvN3enTkQwX8zdyqSZG8nOtmHFVYkllHKyeP1+nv14OUnJ6Yy4oDWjL21rQylN\ntdMwOoy/39yDxjFhzF6+m7emrSEjM8vXYZlSYt9oZczr9fLNL/G8PW0t/n4e/nhNZy7q2cSq+qba\nqhUezEM3dUOaRLFME3hxchwpqZlnXtFUeJZQylBmVjYTv93A53O3UicimL+P7E7nljaFijE1QgL5\n8/Vd6CExbNyZyHOfLLdrVaoASyhl5ERaJv+eEsf81XuJrR/OI7f0KNGU88ZUVYEB/tx1ZceTc4A9\n+9FyDiel+joscxYsoZSBw0mpPDNpOevij9C1VTQP3tiNKOt8N+Y0fn4eRl0iXNKrKXsPpfDMpOXs\nP5zi67BMCVlCKWW7Dybz1H+XsSvhOIO6NeKe33UiOKjy3h+iqoqPj7d7oVQQHo+Hawe15OoBLTiU\nlMozHy1nV8KZb2ltKh5LKKVo065E/jVpGUeOpXHN+S0ZeWEb/Pys892YM/F4PAzrG8uNQ1qTlJzO\ncx+vYMd+m7yzsrGEUkpWbErghU9XkpqexW2XtWNoH7toy5jiGtKjCaMuEZJPZPD8JyvYvs+SSmVi\nCaUUzF+1lzc+X4PHA/dd05l+nRr4OiRjKq2BXRsxZmg7UlIzef6TFWzbm+TrkEwRWUI5S98t2sF7\n364nNNifv404h04tbNp5Y87WeZ0bMHZYe06kZ/LCpyvYsueor0MyRWAJpYS8Xi9Tf97C/2Zvdi7U\nGtmdlo0ifR2WMVXGuR3qc+cVHUhLz+alySutplIJWEIpgWyvl49nbmL6r9upWyuUh2/qRqPoMF+H\nZYrB5vKqHHq1q8ftw9o7MxV/utL6VCo4SyjFlJWdzcTp6/lp+S4ax4Tx8E3diI4K9XVYxlRZvdvX\nY+xl7TmR5jR/7TxgQ4orKksoxZCZlc1/vlrHgjX7aNEwggdu7GazBRtTDs7tWJ/RQ9uS7HbU7z5o\nd3+siMr1figiEgZ8DEQB6cAoVd0jIlcDzwM73ZeOU9V5IvIUcAHgBR5S1Z9FJNrdRgiwBxijqifK\nOvaMzCze+nItKzcfpE2TKP54TWdCg+12MsaUl/6dG5Kd7eWD75QXPl3BwyO7U9daByqU8q6hjAWW\nqOpAYBLwgLu8O/CAqg5yf+aJyDlAL1XtA4wAXnFfOw6YpKoDgBXAnWUddHpGFq9NXc3KzQfpEFuL\nP13XxZKJMT4wsGsjRlzQmqPH03nhkxUcOZbm65BMHuWaUFT1FeBp92EzIOcG092AW0Vkroi8ICL+\nqroCuMR9PjbPa/sB37l/zwCGlGXMaRlZvDp1FWu2HaZzyzrcd01nggNtKhVjfOWink246rzmHDya\nygufrrBZiiuQMjvNFpHbgPtPWTxaVZeJyCygA3CRu3wm8IWqxovI28BdwBuqmuU2e90L3OO+NgLI\nGZR+HDjjWN2YmPASvYfUtEz+/d4i1sUfoXeH+jx4Sw8CAyp3MilpWVQ18fHxvg6hQqlsx8WtV3UC\nfz++/HkLr05dzdO/70dYaGCpbLuylUVFUmYJRVUnABMKeG6wiAgwHWgFTFTVRPfpacDwPK99RESe\nARaKyHwgCSepJADhQCJnkJBQ/KGGaRlZvDIljg07EunWJobbhrYl8UjlngU1Jia8RGVRFVlZ5Kqs\nZTGsT1MOJ55gbtweHh3/C3++vstZn/BV1rIoCyVJrOXa5CUiD4nISPdhMpBzm7Y4EWnk/j0EWCoi\ng0TkdXdZGpABZAMLgKHu8kuBuaUdZ95k0r1NDHdd2cFu12tMBePxeLjlYqGHxKA7Exn/1Tq7R72P\nlfe35HvATSIyG2ek1hh3+VjgcxGZgzN66x3gZ8DPrZXMBV5X1XjgSWCEu7w38DqlKD0ji1c/W3Wy\nZnKnJRNjKiw/Pw+3D+tA26ZRLN+YwH9/ULxeSyq+4qkGhe8tahU2I9MZzbVm22HOaR3N76/qWKWS\niVXnc1lZ5KoKZXEiLZNnP1rOjgPHGdY3lqsHtCjRdqpCWZSWmJjwYk+XXnW+Lc9SZlY2b36x5uRo\nrruurFrJxJiqLDQ4gD9d14WYqBC+/iWeWct3+Tqkasm+MXGmUxk/bS1xWw7RoXlt/nB1RwIDrGiq\nMpvLq+ov5AWDAAAgAElEQVSJrBnMX67vSkSNQD6auZEVmxJ8HVK1U+2/NbOzvUyYvp5lGxNo2zSK\ne37XqdIPDTamuqpbqwZ/vLYLgf5+jJ+21mYoLmfVOqF4vV4+/F5ZuHY/LRtF2EWLxlQBzRtEcNeV\nHcnIyuaVKXEcSCzzmZmMq9omFK/Xy+RZm5kbt4em9Wryp2u7EBJk06kYUxV0bR3NTRe2ISklg3//\nL47jJzJ8HVK1UG0Tyje/xPPDkp00qFODP1/flRohpXOVrTGmYhjcrTGX9m7KvsMpvD51FRmZ2b4O\nqcqrlgnlp2W7+GLeNqIjQ/jriHOIqBHk65CMMWVg+Pkt6dG2Lht3HeXD7zbYNSplrNq18fy6dh8f\nzdxIZFgQfxnRlVrhdj+T6ig+Pt6uN6gG/DwebrusHYeOnmDBmn3Ur1ODy86N9XVYVVa1qqGs2nKI\n96avJzQ4gD9f35V6tWr4OiRjTBkLDvTnvuGdqR0RzNSft7J0wwFfh1RlVZuEsnnXUd78YjV+fh7+\neE1nmtSt6euQjDHlJLJmMPcNd0ZxvvvNOhtOXEYKbPISkW2FrOdV1ZLNbeADuw8m88pncWRmebl3\neCfaNInydUjGmHLWtF44d17RgdemruK1qasYN7onUXYL71JVWA1lkPszG2ca+v5AX5zJGGeUfWil\n42DiCV6avJLk1EzGDG1Ll1bRvg7JGOMjXVtHc82gliQeT+f1z1eTkZnl65CqlAJrKO7MvohIF1W9\nNc9TL4rI8rIOrLQ8+s6vHDmWxjXnt6Rfpwa+DscY42OX9GrKrgPH+XXtfj78Trn1snZ4PMWeB9Hk\noyh9KB4RGZzzQESG4tybpFLYse8YQ7o749GNyWFzeVVfHo+HUZe0JbZ+OAvW7GPmkp2+DqnKKMqw\n4duAD0WkAeABtgMjC1+l4nj5/oGEB/vZGYgx5qSgQH/uHd6Zx99fwuTZm2kYE0bH5nV8HVald8Ya\niqquUNVOQDegtap2U9V1ZR9a6WjVJAo/SybGmFPUCg/mnt91wt/Pw/hpa0mwOb/O2hkTioi0FJHF\nwEpgi4isEJE2ZR+aMcaUrZaNIhl5kZCcmsnrn68mNT3zzCuZAhWlD2U88Jyq1lbVWsAzwH/KNixj\njCkfA7o05PyuDdl54DhvTImz6VnOQlESSrSqfpbzQFX/B1hjozGmyrhhSBtaNIxgzvJd/LTM7vZY\nUkVJKKki0j3ngYj0AJLLLiRjyl58fDzLlq3xdRimgggM8OPuqzoSVTOYybM2s3Fnoq9DqpSKklDu\nB6aKyHL3+pOp7jJjjKkyakeE8MAtPfB64c0v15B4PM3XIVU6RRnltRBoDdwMjMIZ6bWwrAMzxpjy\n1qllNNcOaklScjrjp60lK9vuoVIcRRnlVRf4CJgLzAcmi0i9sg7MGGN84aKeTejWJgbdmcgXcwub\n0tCcqigXNo4HFgBjcRLQHThze11e3J2JSBjwMRAFpAOjVHWPiFwNPA/kXLL6qKrOddepAfwCPKiq\n34tItLuNEGAPMEZVbQC5MaZUeDwebh3ajl0HjvPtwu20ahxJV5sDsEiK0ofSQlVfUNUkVU1U1eeA\n2BLubyywRFUHApOAB9zl3YEHVHWQ+zM3zzpvANlAzli+ccAkVR0ArADuLGEsxhiTrxohAdx9dUcC\nA/x49+t1dtFjERUloWSLyMmJsESkGU7tothU9RXgafdhM+CI+3c34FYRmSsiL4iIv7uvv+I0s8Xl\n2Uw/4Dv37xnAkJLEYqo3m8vLnEnTeuGMvLANKWmZvPXlGrsnfREUpcnrH8Av7tXyAH1wmr0KJSK3\ncfposNGqukxEZgEdgIvc5TOBL1Q1XkTeBu4SkQ1AK1W9S0T648wjBhABHHX/Pg5EFuE9GGNMsfXv\n0pCNuxJZsHofn83Zwg1DWvs6pArNU5SrQt2O+Z44NZpFqnrW99AUEQGmq2orEYlS1UR3+aXAcCAU\npxaTAbQF9uOMMnsPuERVE0SkC/Ckqg4rZFd22as5TWxsLOBcj2JMYVLTMvnzKz+zc/9x/m9ML3p3\nrDa3wSj2JIhnrKGISG3gGiDa3UE3EfGq6uPF3ZmIPATsUtVJOBdH5kycEycifVV1N04T1lJVfTvP\nehOBT1Q1TkQWAEOBD4BLcUafFSoh4VhxQ62SYmLCrSzyyM72Wnlgx0VeBZXF7Ze154kPl/LyJ8t5\nbEwv6kSG+CC68hUTE17sdYrSh/Ilzp0b8762pNP3vgfcJCKzcUZqjXGXjwU+F5E5OKO33ilkG08C\nI0RkPtAb5w6SxhhTZhrXrcmNQ1qTnJrJ+K/Wkpll/Sn5OWOTl4isdqevr6y8dvblsDPRXD17diI7\n22vTr2DHRV6FlYXX62X8V2tZvP4AQ/s045rzW5ZzdOUrJia82BWHotRQ1rjzdxlTZdhcXqa4cu70\nWDcqlG8Xbmdt/GFfh1ThFJhQRGSbiGzDae5aJCI7c5aJyNbyC9EYYyqG0OAA7ryyA/5+Ht79Zh3H\nUkp0BUWVVVin/CD3t5fT+0xs5JQxplpq3iCCqwe04LM5W5j47QbuHd7JbjHuKqzJq6OqxgPnAwPy\n/Ax0f4wxplq6pHdT2jWrxcrNB5mzYrevw6kwCksoPd3fgwr4McaYasnP42Hs5e0JCwng01mb2X3Q\nbhEFRbywsZKzUV4uG82Ty8oil5VFruKWxTJN4I0vVtM4pib/GNWdwAD/MoyufJVklFeBfShuh3xB\nvKraorg7M6aiiI2NtWHD5qx1lxgGdm3Izyv38PncrVw/uHpPzVKUTvkc+XXOG2NMtTZicGs2bD/C\nD4t30rllNO2a1fJ1SD5TYB+Kqsbn/ODM8HsHkAAMcJcZY0y1Fxzkz9hh7fF4PEyYvo6U1Axfh+Qz\nRblj47M4c2f9DqdGc6uIvFTWgRljTGXRsmEkl/dtxuGkNCbN3OjrcHymKFfKX4xzP/lUVT2KM3nj\npWUalTHGVDKX942leYMIFq7dz+L1+30djk8UJaFknfI4OJ9lxhhTrQX4+3H7sPYEBfrx4XfKkWNp\nvg6p3BUloUwBPgVqi8ifgHnAJ2UalTFlzObyMmWhfu0aXD+oFSlpmUycsZ5qcFnGb5wxoajqv3Cm\nnZ8CNAHGqepTZR2YMcZURuef04gOsbVYs/Uw81bt9XU45aoonfLDVPU7Vf2rqv4ZWC4iU8shNmOM\nqXQ8Hg9jhrYjNNifT37axMHEE74OqdwUpcnraRH5HYCI3A2sAOLKNCpjjKnEakeEcOOQNqSlZ/He\nt+vJriZNX0VJKBcAD4vIcuAqoF9Jbv9rjDHVSd+O9enaKpoNOxKZvbx6TCBZ2P1QBorIAKAtzm13\nGwDTgYbucmOMMQVwbsglhIUEMGX2ZvYfSfF1SGWusBrKP/P83A8oTg0lZ5kxlVZsbCzdu3f0dRim\niousGczNFwvpmdlM/HZDlW/6KnAuL1U9vxzjMMaYKqln27osXn+A5RsTmL18Nxd0b+zrkMpMYbMN\nv6Oqt4vI7Hye9qrq4DKMyxhjqgSPx8PNF7VBdxzhszlb6NKyDtFRob4Oq0wUNtvw2+7v/Jq3qna9\nzRhjSlFkzWBuGNKad79Zz/vfbeAv13etkrcNLqzJa5n7e86pz4nIm8DPZReWMcZULed2qM/i9QdY\nteUQc+P2MLBrI1+HVOqKMmw4PzeXahTGGFPFeTwebrlYCA32Z/KszRxOSvV1SKWusCavUiciYcDH\nQBSQDoxS1T0icjXwPLDTfek4VZ0nItOAOkAGkKKql4lItLuNEGAPMEZVq8+lqKZUxMfH221vTbmr\nHRHC9YNb8/6MDfz3e+W+azpXqaavktZQSmossERVBwKTgAfc5d2BB1R1kPszz13eSlXPc5dd5i4b\nB0xS1QE4V+3fWZ5vwBhjzkb/zg1o16wWcVsOsWTDAV+HU6oKG+WV3+iuHCUaoqCqr4hIThJrBhxx\n/+4GdBWR+4HFwINANBAlIl/j1Gj+parTce4e+aS73gzgaeDfJYnHGGPKm8fj4ZZLhHETFvPxzI20\nj61NzdBAX4dVKgpr8ipodJeHIozyEpHbcC6IzGu0qi4TkVlAB+Aid/lM4AtVjReRt4G7gGnAC8Ar\nOM1eC0RkMRABHHXXOw5EnikWY4ypSOrVqsFV5zVnypwt/G/WZm69rJ2vQyoVhY3ymnPqMhH5p6o+\nWpQNq+oEYEIBzw0WEcGZyqUVMFFVE92npwHDgfHAeFXNBhJEZAUgQBJOUkkAwoHEU7d/qpiY8KKE\nXC1YWeSysshlZZGrvMripqHtWbbpIPNX7+XivrF0bVO3XPZblorbKX8FUKSEkh8ReQjYpaqTgGQg\n030qTkT6qupunFsML3V/3wtcJiI1gY7AemABzj3uP8C5FfHcM+3XOl8dMTHhVhYuK4tcVha5yrss\nbr6wDU98sJRXJ6/g8dt6ExzoX277PpOSJNby7pR/D7jJ7Z/5GBjjLh8LfC4ic3BGb72jqt8BG0Xk\nV+B74GFVPYTTfzJCROYDvYHXy/k9mCrA5vIyFUGz+uFc1KsJCYmpfDV/m6/DOWvFraGMO5udqeoB\nnFrFqctn4vSjnLr8T0XdhjHGVEZXntecpRsO8MOSnZzboT6N69b0dUgldsaEIiKPktsZj4h0BU4A\n691RV8YYY0ooONCfkRcJ/54Sxwffb+Dhkd3xq6TXphSlyaslTo3gCE4H+IXA+cDtIvJc2YVmjDHV\nQ+eWdejZti5bdicxd+UeX4dTYkVJKG2B81X1VVV9BaezPFpVrwIuKdPojDGmmrhhSGtCg/35bM4W\njh5P83U4JVKUhBIF5L3qJhjIaeSrnPUyY4ypYKJqBjN8YEtS0jL5dNZmX4dTIkXplH8dWOpese6P\nM2T3Vfeq9lVlGZwxZcXm8jIV0fldG7Fg9T4WrdtPv0716di8jq9DKpYz1lBU9VXgOpyJGOOB4ar6\nJs5FiWMKWdUYY0wx+Pk596H383iY9MNGMjKzfB1SsZwxobhzb53n/lwADBERP1XdpKrpZR2gMcZU\nJ03rhXNB98YcOHKCGYt2+DqcYilKH8pzOHNufQBMBAYDL5VlUMYYU51d1b85kTWDmP7rdg4kVp67\ncxQloVyE08z1lap+iTPPlo3uMsaYMhIaHMD1g1uRkZnNxzM34vVWjruuFyWh+PPbzvsAcufgMsYY\nUwZ6t6tHu2a1WLXlECs2HfR1OEVSlITyETBHRO4VkfuA2cAnZRuWMWXL5vIyFZ3H42HkRW3w9/Pw\nyY8bSUuv+B30RRnl9TTwBM4NsZoBTwGNyjguY4yp9hrUCePiXk05lJTG17/E+zqcMyrS5JCq+i3w\nbc5jEfkEuLusgjLGGOMY1jeWhev28f3iHfTv3IB6tWv4OqQClff09cYYY4ohOMif6we3Jivbyyc/\nbfJ1OIWyhGKMMRVcD4k52UG/cnPF7aAvsMnLvQlWQULLIBZjjDH58Hg83DikNY++t4RPftxIh9ha\nBAZUnLs75iisD+WfhTxXOQZFG1MAm8vLVDaNYmoypEdjfliyk+8W72RY31hfh3SaAhOKqs4pxziM\nMcacwRX9mrNw3X6m/xJP3w71qRMZ4uuQfsP6UIwxppKoERLAtee3JD0zm8mzK94U95ZQjDGmEjm3\nY31aNIxg6YYD6I4jvg7nNyyhGGNMJeLn8XDDkNYAfPLTJrKzK06XtiUUY4ypZFo2jOTcDvXZsf84\n81fv9XU4J1lCMdWSzeVlKrtrzm9JcKA/U3/eQkpqxZiv1xKKMcZUQrXCg7ns3GYcS8ngmwoyz1eR\n5vIqLSISBnwMRAHpwChV3SMiVwPPAzvdl45T1XkiMhq4C2cK/Wmq+qSIRLvbCMG5LfEYVa08d6Ax\nxphScnGvJsyN28PMpTsZ2LWhz+f5Ku8aylhgiaoOBCYBD7jLuwMPqOog92eeiLTESSYDgd5AkIgE\nAOOASao6AFgB3FnO78EYYyqEwAB/rhvUiqxsL5Nn+X4YcbkmFFV9BXjafdgMyBnz1g24VUTmisgL\nIuIPDAGWAh8Cc4AFqpoJ9AO+c9eb4b7OGGOqpe4SgzSJYuXmg6yLP+zTWMqsyUtEbgPuP2XxaFVd\nJiKzgA44txcGmAl8oarxIvI2Ts0kEhgAnAvUAOaLSC8gAjjqrnfcfZ0xxlRLHo+HERe05vH3lzB5\n1mYeHd0TPz+PT2Ips4SiqhOACQU8N1hEBJgOtAImqmqi+/Q0nPvWLwHmqGoykCwi64E2QBJOUkkA\nwoHEU7d/qpiY8LN8N1WHlYUjPj7e1yFUKHZc5KqMZRETE86gHk2YtXQnq+KPcGHvZj6Jo7w75R8C\ndqnqJCCZ3HvTx4lIX1XdTW5T1wLgDyIS7MbZHtjsLh8KfABcCsw9035tEkBHTEy4lYXLyiKXlUWu\nylwWl/VuyvyVu/lg+jraNo4gJOjsvt5LkljLu1P+PeAmd2r8j4Ex7vKxwOciMgdn9NY7qroGp4az\nACdpPK6qR4AngREiMh+ns/718n0LxhhT8dQKD+aS3k05mpzOjIU7fBKDx+utOJftlxFvZT3jKG2V\n+eyrtFlZ5LKyyFXZyyItPYuH/vMrJ1IzefqOPtSOKPlsxDEx4cXuiLELG40xpooIDvJn+ABnNuKp\nP28t9/1bQjHGmCqkb6f6NK1bk4Vr97F9X/nWtiyhmGrJ5vIyVZWfx8O1g1vhBf43ezPl2a1hCcUY\nY6qYDrG16diiNuu3H2HNtvK72NESijHGVEHXnt8KD04tpbzumWIJxRhjqqAmdWvSr1MDdicks6Cc\n7pliCcUYY6qoq/o3JyjAjy/mbSUtI6vM92cJxRhjqqjaESFc2LMJicfT+WHJzjOvcJYsoZhqKT4+\nnmXL1vg6DGPK3NA+zQivEciMhdtJSkkv031ZQjHGmCosNDiAy/vGkpqexfRftpfpviyhGGNMFXd+\n10ZER4Ywe8UuDiaW3Q1uLaEYY0wVFxjgx9UDWpCZ5eWLedvKbD+WUIwxphro3b4eTdwpWXYeOF4m\n+7CEYowx1YCfx8PwgS3xAlN/3lI2+yiTrRpTwdlcXqY66tSiNtIkilVbDqE7jpT69i2hGGNMNeHx\neLhmUEsAPpuzpdQnjrSEYowx1UjLhpF0bxPDlj1JxG0+VKrbtoRijDHVzFUDWuABPp+7hexSrKVY\nQjHGmGqmUXQY53asz66EZBav319q27WEYowx1dCV5zXH38/Dl/O2kZmVXSrbtIRiqiWby8tUdzFR\noQzo2pADR04wv5Smt7eEYowx1dSwvrEEBfjx9YJ40kthentLKMYYU01F1Qzmgh6NOXIsjdkrdp/1\n9iyhGGNMNXZp72aEBvsz/dftnEjLPKttBZRSTEUiImHAx0AUkA6MUtU9InI18DyQcweYR4FQ4CH3\nsQc4D+gAHHK3EQLsAcaoatlNn2mMMVVYzdBALu7VlC/nbePHZbsY1je2xNsq7xrKWGCJqg4EJgEP\nuMu7Aw+o6iD3Z66qfp/zGPgG+JeqKjAOmKSqA4AVwJ3l/B6MMaZKubBHE8JCAvh+0Q5SUjNKvJ1y\nTSiq+grwtPuwGZAzmUw34FYRmSsiL4iIf846ItIYuBn4p7uoH/Cd+/cMYEiZB26qHJvLy5hcocEB\nXNqnGSlpmWd1q+Aya/ISkduA+09ZPFpVl4nILJzmq4vc5TOBL1Q1XkTeBu4C3nCf+zPwkqrmpM0I\n4Kj793EgsqzegzHGVBcXdGvMD4t38MOSnQzp0YSYEmyjzBKKqk4AJhTw3GAREWA60AqYqKqJ7tPT\ngOEAIuIHXAY8nGf1JJykkgCEA4mcQUxMeAnfRdlYtGgRkydP5qWXXjrrbe3atYu//OUvTJ48+TfL\nn376acaMGcNnn31GTEwMI0aMAAovi/POO4/58+cXuO7Z+uSTTzh06BD33HNPqWzvbPn5eSrcseEr\nVg65qnNZXDtEmPDVGuau3kfzprWLvX55d8o/BOxS1UlAMpAzpCBORPqq6m6cJqyl7vKOwAZVTcuz\nmQXAUOAD4FJg7pn2m5BwrJTeQek4evQEqakZpRLX4cPJZGRknbat22+/F4CUlHSOHUslIeEYMTHh\nhe4zOzubhIRj+a5bGo4fTyU5Oa3C/D+ys70VJhZfOtNxUZ1U97Lo2boOU2sG8dW8LYy6rH2x1y/X\nhAK8B3zgNof5A2Pc5WOBz0XkBLAWeMdd3gY49U4wT7rbuB2nlnLj2QT0v1mbWbLhwNls4jQ929bl\nusGtCnw+vymjlyxZyDvvvE1QUBCRkZE8/PCjhIWF8eKLz6K6njp16rB37x6effZl6tdvcMYY7rnn\nDh544O8nH+/atZO7736Uv/7179StW59//etxkpKSALj//r/SokWrfNedP/9nZs/+iaSkRMaO/T39\n+vXnhx9mMGXKJwQGBtG4cRMeeOARAJ5++p/s3bubrKxsrr/+Ji644ELi4lby6qsvEh4ejr9/AB06\nWL+FMRVVUKA/l50by0czN5Zo/XJNKKp6AKdWcerymTj9KKcu/wz4rCjbqMy8Xi/PPfcMb701gejo\naKZM+ZQPPphAly5dOXbsKO+88wGJiYmMGHE1zgjqM/N4cl+3Y0c806d/xauv/pvQ0Fq8+ear9OjR\ni6uuuoadO3fwzDOP8+ab7+a7bkxMPR588BFWrFjGxx9/SKdOnXnvvf8wceLHhIaG8tprLzFt2ueA\nl1q1ajNu3BOkpKRw660j6dGjJy+++AxPP/0CjRs34YUX/lVaRWaMKSMDujRkxqLtJVq3vGsoFc51\ng1sVWpsoD0ePHiUsLIzo6GgAunY9h/Hj3yAyMpIOHToDEBUVRbNmsYCXBx74EydOpNCyZWtGjLjp\njNtftOhXAgICTiaKrVs3s2LFUn76ycnhx44lFbiu09UFtWvXITU1lT17dtO8eQtCQ0MB6NKlG4sX\nL8TPz0OPHr0BqFGjBs2bN2f37l0cOXKExo2bANC5cxd27Sr5CJLSFB8fX62bNowpSGCAH7cNbVei\ndat9QqkIIiMjSU5O5tChg9SpE82KFcto2rQZLVq04vvvpwM3kJSUxM6dOwAPzz338sl19+7dc8bt\nX3fdjTRs2IiHHnqIl156k2bNmtO2bTsuvPASjhw5zDfffFXI2r+tETVo0JBt27aRmppKSEjIyVj9\n/f2Ji1vBgAHnk5KSzJYtm2nQoBExMTFs3x5Ps2axrFu3loiIiJIVkjGm3LSLLX6HPFhC8QmPx8OS\nJYsYO/aWk8tuuWUMjzzyAB6Ph4iICB555DEiIiJZuHABv//9rdSuXYeQkBACAk7/l23duuU327rn\nnvt/02wF0LNnbxYunMtHH33IqFG38swzT/DVV1+QnJzMbbflXBt6enNa3u14PB4iI6O47bY7uPfe\nO/Hz86Nx4ybcffd9eDwenn32Se6+eyxpaWnceusd1KpVi7/97e88+eQ4atSoSY0aNYiMtFHexlRV\nntK+p3AF5K2sTRs7dsSzadNGLrjgIo4eTeSWW65n6tTp+SaVoqjuI1jysrLIZWWRy8oiV0xMeNE6\nbPOwGkoFVrdufd566zX+979PyM7O4ve/v6/EycQYY8qafTtVYCEhITzzzIu+DsMYY4rEpq83xhhT\nKiyhGGOMKRWWUIwxxpQKSyjGGGNKhSUUH1i+fCmXX34h995758mff/zjoQJfv3//PhYsmAfAq6++\nyP79+0q876SkJGbO/O7ML3Tdccdo9u377f6eeuoxRo26gXvvvZP77ruLe+65g23btpY4prORt2yK\n47XXXmPChPG/Wfbzz7N54ol/5Pv6p556jEWLfi1RjMZUFzbKywc8Hg89evTisceeKtLrly1bwo4d\n2+nXrz/33feXs9r35s0bmT9/LhdeeEmRXn/qBZI5y/7whz/Sq1cfABYu/IV3332Lp556/qxiK4m8\nZVMcw4cP5+abb8lzUSdMn/4VN900Kt/XezyefMvCGJPLEgoUeOe+ZcvWlMrrT+X1evOdcRjg88+n\n8N130/Hz86Nt2/bcd9+fmTTpfdLT0+nYsTOTJ3/E3/72MDNnfs+ePbtITDxKUlIiv/vddcyZ8xM7\nd+7gkUf+SYcOHXn77ddRXc/Ro0dp1ao1L7/8Ah9++B5btmzm66+/pFevPjz//NOkpaURHBzMAw88\nQt269Rg//g0WL15I3br1OHo0/9vN5I0/KekoNWqEAZy2z7///VEmTBjPmjWrSE09wUMPjWPGjG/y\nfc2Z3s9nn33Kjz/+gMcDF1xwEb/73XVMmvQ+aWlpdOrUhfr1G/DKKy/g9XrdGZvHobqBt956jaCg\nIK644mouvngoAA0bNqRx4ybExa2gS5dzOHToIPv376VTp878619PcODAAQ4dOsh55w3g9tt/f/I9\nf/vt1+zYsZ277rqHtLQ0Ro68lilTvmLLls2n7TssrGaRjgdjqgpLKD6yfPlS7r039+y4b9/+3HDD\nSGbM+Jq//OVh2rZtx5dffobX6+Xmm8ewY8d2zjtvAJMnfwQ4Z8zBwSG8+OITTJr0Pr/+uoBnn32Z\nb7/9mp9++p7mzZsTERHByy+/QXZ2Nrfccj379+9n1KjbmDbtc4YNu4px4x7mmmtG0KdPX5YuXczb\nb7/OddfdyKpVK5kw4b+kpCQzYsTvTovd6/Xy5puvMmnS+/j5+RMTE8Pdd99HSkryafs8eDABj8dD\n8+YtuO++vxT6msLeT1hYGLNm/chbb00gOzubP//5Hnr1Ovdk2fTr15877hjNI488RrNmsXzzzTQ+\n+uhDevbsTUZGBu+888Fp72PYsKv57rtv6dLlHL77bjqXXXYlBw7sp2PHTlx++VWkpaUxfPhlJxNK\nTrnn59lnn8yz7y/56KMPueOOu8/2MDGmUrGEQtFrFiV9fX66devBP//59GnLH374UT79dBJ79uym\nY8fOJ2sz+dVo2rRpC0DNmuE0b97i5N/p6ekEBQVz+PBhHnvsEUJDa5CSkkJWVtZvtrV162b++9+J\nfFqtGs8AAA7XSURBVPTRB3i9XgIDA9m5cztt2zozjdaoEUaLFi1P2++pTV45MjMzOXLkyG/2mZnp\n3EOtSZNmAAQFBRf4msLez9atW9i3by/33XcXAMePHzs5c3HO+9m+fRsvvPDMyViaNGnK/7d35lFW\nVVce/qoYomDZRgEHZBJwy2AUwYjYQszS2OrCZaKRhahRxBFM0woaokJjVBJFG1Bsg1MwRokY0EUc\noqJpSgjIpDLIbwUVDQEZlGgGgZKq/uOcR716detVpXjvVSj2t1atuvXuuefsu9+ts+8+957fAWjf\nvkPid3DKKacybdpUdu7cydy5rzB58kMUFxfx3nurWbZsKS1atKSsrCzx2EDld1JT246zL+EB5V+M\nOXOeY9SoMTRv3pwbbrielSvfpbi4mPLy8ixHVQ84CxcuYMuWTYwfP4Ft27ZRWvoGFRUVNGnSZHfZ\nDh06MnjwJfTs+Q0+/ngdy5cvo2PHo5g1ayYVFRVs376ddes+TG4xIcAtXDifzZs/qdYmVN7ZZyuT\n7Xzat+9Ap06duffeKQA888xTdO7cheXLl+72Tfv2Hbnttttp0+ZQVqx4h08/3Vql7UyaNm3Kqad+\ni8cff5hOnY6ipKSEmTNncMABJYwe/WPWr/8Tc+bMrnJM8+bNd9crrUmzL7ltx9mX8IDSABQVFVUb\n8ioqKuKeeybTuXNnhg8fRosWLWndug09ehxLy5YteeKJxzA7ppr6b9zavR1+FdG9ew+mT3+EESOu\nAuCII45k8+bNtG17JB98sJaZM2cwfPhIJk78KTt37mDHjh2MHDmarl2Ppm/ffgwbdimtWrXi4IOT\nZayTOunu3XsyffqjVdrcunVLlfJ1KZN0Pl26dKV37xO59torKCsro3v3HrRu3YbOnbtE33Rj1Kgx\n/OQnY9m1axdFRUWMGTOWLVs2Z32YPnDgeVx88feZNOlBAPr0+Sbjx9/KqlUraNasGe3ata9i30kn\n9WP27Ge57rphmHXb/ZwkqW3H2ddwteF9CFdSrcR9UYn7ohL3RSX1URv2eSiO4zhOTvCA4jiO4+QE\nDyiO4zhOTvCA4jiO4+QEDyiO4zhOTvCA4jiO4+SEgs5DMbOWwFPAQcBO4AeSNpjZd4F7gD/FomMl\nlZrZfcApQDlwo6QFZtYq1rEfsAG4XNKXhTwPx3EcpzqFzlCGAYslDQCeBG6Kn/cGbpJ0WvwpNbPj\ngJMlnQRcAkyJZccCT0rqDywHrsZxHMdpcAoaUCRNBlICVh2AbXH7BGComc0zs4lm1gRYD/zDzL4G\n/Bsho4GQsaQW9HgJOL0gxjuO4zhZyduQl5ldAYzM+PgySUvN7HWgB/Cd+PmrwGxJ68zsIeAaQgZT\nDqwhBJRhseyBwOdx+29xn+M4jtPA5C2gSHoUeLSGfd82MwNeALoAj0tKLbzxPHA+IXv6hBB0DgTe\nNLNFwBfx7y1ACZC8YEclRa1bl+zh2TQe3BeVuC8qcV9U4r6oPwUd8jKzH5nZxfHPvwNfxe13zKxt\n3D4dWEIYDvubpApCJrIDaAnMB86OZc8C5hXCdsdxHCc7BRWHNLM2wHTCG1pNgJsl/cHMzgDuAL4E\nVgE/JCw2MRX4Riw7Q9KktDpKCFnKRf6Wl+M4TsOzL6gNO47jOAXAJzY6juM4OcEDiuM4jpMTPKA4\njuM4OaHRLgEc5VwukDQkYd+VwFWEt8zukPRCoe0rBGa2P2E+T2vgrwSpm60ZZW4EBhPm/Nwl6bmC\nG1oA6uiLswhKDEXAUknDC25oAaiLL2K5YsKr/c9J+nlhrSwMdbwu/gsYFP98UdLthbUyv8Tv+UHC\nC1A7gGGS3k/bPxC4jdBfPibpkZrqapQZipmlZuRXW8LSzA4Drgf6AWcCE8yseWEtLBjXAu9EmZon\ngFvTd5rZQYQ36voS5vtMKriFhaM2X5QAdwPnSOoLrIu6cY2RrL5I4w6C7l5jfnOntuviKOAiggxU\nX+A7ZnZs4c3MK+cBzSX1A34E3JvaYWbNgPuAM4ABwFXxTdtEGmVAIcxVuZaEgAJ8E5gvqUzSF8Ba\nQmRujKTL1LxMdZmavwMfAQcQXsPeVTjTCk5tvugHrADuM7N5wKaku/ZGQm2+wMwuIFwPL5P8f9RY\nqM0XHwNnxvlwAM0I0xsaE7t9IGkR0CdtXzdgraTPJZUBbwL9a6porx7yyiLv8oyZfauGw0qolG6B\nkObu9fItNfhiE0FZAGo+z/XAasJcn7sS9u911NMXrYDTgOMIgbbUzP4g6Y/5tDXf1McXZtaTMAx6\nATAu3zYWivr4QtJXwGdmVkRQRF8maW2+bS0wB1LpA4BdZlYsqZyqUldQS3+5VweUbPIuWfiCEFRS\nlFApUrnXkuQLM/sNleeaJFNzFnAY0JFwF/o7M1sgaXF+rc0v9fTFVoIS9uZYfh5wPLBXB5R6+uIS\noC3wOuHa2GlmH0p6Jb/W5pd6+gIz2w94jNCxXpdnMxuCzD4xFUwgnHOd+8u9OqDUk7eAO6OK8X6E\nlG5lw5qUN1IyNYtJlqn5DPhS0k4AM/sLjSBbq4HafLEc6GlmhxD+ifoC0wpqYeHI6gtJN6e2zWwc\nsHFvDyZZyOqLmJk8D8yVdHfhzSsI84GBwEwz6wu8m7ZvDdDVzL5OyNz7EzK1RBpzQKkg7WFifFNj\nraQ5ZjYFKCU8Q/pxqkNthPwvMN3MSglvb1wE1Xyx2MwWEt7yKpX0WsOZm1fq4osxwO9i+V9LWt0w\npuadWn3RkMYVmKy+IAwF9weaxbcAAcZIWtgQxuaJ2cAZZjY//n25mQ0GDpD0sJndQPi/KAYelbSx\npopcesVxHMfJCY31LS/HcRynwHhAcRzHcXKCBxTHcRwnJ3hAcRzHcXKCBxTHcRwnJ3hAcRzHcXJC\nY56H4uQJM3uAoP/THOhCkG4BmCRpeh7auwwYIOnyhH2XAiMIGkvFwCOS7q9HG52AWyQN20NzM+t9\nAbgC2L++9UcRz18BnQjLXl8oaVNCuYnAOYQ5RVdKWpC2ry2wRNLhNbRxIDCBMOfiK8Js6BslLTez\njsAbkjplHFMuqTjKHP2WqqoCFUCftBnXqWPOBTpIuj+Kso4FziXohm0HbpU0t26eATM7kqAYflld\nj3Hyh2cozj+NpBGSehFmGG+Q1Cv+5DyYRBInS5nZVcB/AgOjPf2Bi81saD3a6AB0rr+JyUg6R9In\ne1j/HcD/SeoOPAxMziwQxRyPkdSNoB47PcqSY2ZnA28AiSqxsdyLBPmZ46IvbwdeijOk68LitOug\nl6QTEoLJ14CbCVLpAL8gSP/0iW1eCTxpZsfUsU0krQc2pU06dBoQz1CcPSFpeYB1wEKCDtapBDG+\nbwMHEzqs7xHWlugq6fp4zETgzwSpkweBHoQZyj+TNCOpncgtwCWpu3VJn5vZDwiCdkQZiUkEiZ2t\nwNWS3o8zfy8l3Mm/JekaYArQyczuT9mVcG4dSbtTN7P/BiokjTezjcBM4N8Jd/gXSloX/TEgvX7g\nZ4SMo0W04YeSFpnZeEKAzlx75OzoS4AZwFQzayJpV0aZp6Mf/mhmHxGyyFJgKPBdgppyEqcBh0va\nLQQp6fcxM8xlHzGEEBh3mVkXgtxHm5RShaSVZjaIqOZrZneSce1I2mRmW4AlxGBEkJ2fCryUQ1ud\neuAZipNrKgiLEB1D6NiPlnSyJCNIWQwhdHznmVlR1Eo6H3iKsIjPEkl9CJ3wLXEoqhpxrZJ2wKL0\nzyWtkfRWHE55Ghgu6XjgIeBpM2tCWPOhd/wpN7MjCGvkLKkpmGQ511T2dCjwmqQTCHpQIzLKpNd/\nBTBH0onATYQghKRxNSxkdQSwMZb5iiDm17qmMpGNwJHxmAskrcpyHr0IGndVkPSypC2p+s1sefoP\nVTPHPhn7Bye0M5BKrazjgVWSqkjBS5on6aMYcJKuHYBDgAkxE9oVz627mTVWHbq9Bs9QnHywCCBm\nA6Pi0JQBJxO0oraY2duEu8+yUFSbzOx0YP+0IasWhGwlacgrNZxSU/ZyNLBN0tJoy7NmNg1oCSwg\n3OE+D0yVtMHMjt7Dc4bKdTVWUn3NiHQ7XwVmmVkvwoqID9RSb9I5ltehTF3Xt9lF7TeXG+Kw1G7M\nLN2GJZJOq6WOroTlEiDYX+M6K5LWJl07aUUWZRyynjCkuKwWG5w84hmKkw9SQxa9gZRK7UyCCF3q\nmnuSMPR1Ydwm7huSGocndCKpTroKkj4DPgBOTP/czAaY2QSSO6sigjT3eVQuwPaymdW4YFAGFRn1\nVlnpM0NkNFtnuQDoThDcGwTUJsb4Z+BwADNrSsj8Pq2pTORwYEMt9aZYApyQ+aGZ3ZVlXaH6UE4Y\nDky12S1Kw6e3OdLMBtVw7ez2qaQdGXWXUT3IOgXGA4qTT/oDv5c0DXiPsORyk7jvecKw1pnArPjZ\n68T1JuIw1LtAe2runO8B7jWzQ+MxrYCJhLeNBBxiZn3ivguBdUBTM3sPWBGfGbwCHEvokGrL2P8C\nfN3MWsUHzP9RNzcAoSNtGm25m/Ds5wnCUFi1zjyDFwnPfCAEoHkZz09SZYaYWXFquIggyV4rkkqB\nzWY2Lu1B/pnAZUC2obJ/lvcJ66sg6WNCdnZ/9CUxY7uJ8Kwn27WTRDvgwxza6tQDDyjOnpJNrvrX\nwHFm9g4wF3ibyg5lO2E50UWS/hHLjycMea0AXgNGS/qAjKUIUsTnDb8EXo1DaK8Dj0t6LGYLg4AH\nYn3XAYMUlvX9ObDYzJYQ1kz/BaHTOsjMpgPE5wCHZbT3OSGILSYMW6VLmFdkbGfauzqt/inA+fE5\nxCzgmtjmeDO7OsGPtwF9zWxlLDs8lh9oZg9H254ldP7vAs8BQxPu4rN9V+cShoxWxu9rNHBW2jOU\npGMzz7k25hBeAEgxlJDNvh2/v6mEDHU1yddO6nlalbYsrDC5Jn4/TgPi8vWOk4CZ3QeMk/TXhral\nsRAzkTeBk+PLBbmq93+AVyT5W14NjGcojpPMEg8muSVmTHeSw2V0zawd0NqDyb8GnqE4juM4OcEz\nFMdxHCcneEBxHMdxcoIHFMdxHCcneEBxHMdxcoIHFMdxHCcneEBxHMdxcsL/A3+sXcddwLmWAAAA\nAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAEWCAYAAABBvWFzAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/d3fzzAAAACXBIWXMAAAsTAAALEwEAmpwYAABP20lEQVR4nO3dd3gVZfbA8e9JISEhBAhFeugdQ1WqKNhBVFBUVOxgX3WLFbCtWH7quq66roqKKCiKFBsiYKNoAqHXICXUUEInkOT8/pgJXkLKDbnJpJzP89wn9049M7l3zsz7vvOOqCrGGGNMYQV5HYAxxpiywRKKMcaYgLCEYowxJiAsoRhjjAkISyjGGGMCwhKKMcaYgLCE4jER6SMiyT6fl4tIH/f9aBH56DSWeWI+EWkgIgdFJNj9PEdEbgtQ7O+LyDOBWFZpUR63ubQRkR4istb93l/udTxFRUQeFZF33PexIqIiEuJ+/kZEhhV3TJZQ8iAiG0SkX3GuU1XbqOqcAC5vk6pWUtWMQC3TCyIy1D1AHBSRIyKS6fP5oNfxZRGR2iLyrohsE5EDIrJKRJ4UkchCLPMmEfkln2nmiMhRd3/sEpEvRKT26a6zuLgHwaYBXuxTwOvu9/7LQCxQRLqKyNcikioie0TkNxG5ORDLdpd/yn7IdmJ40okngKr+U1VzPDlU1YtV9QN33ny/P4FiCcWUCqo63j1AVAIuBrZmfXaHnZB1NVbcRKQaMA+oCHRT1SjgfKAK0KQYQrjH3RfN3XW+UtAFeLXvTkfW2XgOGgLLA7VMEekGzAJ+BJoCMcCdON/Dgi5fRKTMHnfL7IYVJREJE5FXRWSr+3pVRMJ8xv/dPUPdKiK3FeQsLLerIhEJFZFPRORzEakgInXc9yki8oeI3JfL8k66FHY1FJFf3TPoGSJS3Wf6y9xit1T3rLeVz7gOIrLQnW8iEJ7H/kkVkbY+w2q4VxY1RaS6iEz3Odv7uTA/MrcY6k33DPIQcK6IXCoii0Rkv4hsFpHRPtN/KyL3ZFvGYhG50n3fUkS+d2NbLSJX+xnKg8AB4HpV3QCgqptV9X5VXeIuu7uI/C4i+9y/3X1iuElE1rv79w9xrspaAW8B3dyrj9T8glDVPcDnQFt3uZ+JyHZ3nT+JSJtC7Lus79PN7ri9IjJCRLqIyBL3f/p6tn17i4isdKf9TkQausN/cidZ7G7bEHd4fxFJdJc1V0Ta+yxrg4j8Q0SWAIeyfa8RkSSgMTDNXWaY+1uZ6v4/14nI7T7TjxaRSSLykYjsB27KYZe+CHygqs+r6i51JKjq1e4yqrrf5xR3G6eLSD2fdcwRkWdF5FfgsBuf38S5uv0GqCN/XpXXkTyKxN113pbT98f9X+3w3XciMkhEEgsSV45U1V65vIANQL8chj8FzAdqAjWAucDT7riLgO1AGyACGAco0DSXdfQBknNaJzAa+AjnjPcr4H0gGOdEIAEYCVTA+YKuBy70nc99H+uuP8T9PAdIwjmLreh+HuOOaw4cwjmrDgX+Dqxz11EB2Ag84I4bDBwHnsllu94DnvX5fDfwrfv+OZwveaj76gVIAf4v2ffZ+8A+oIe7b8Ldadq5n9sDO4DL3elvBH71mb81kAqEAZHAZuBmIAToCOwC2visK7dtng88mUfc1YC9wA3usq91P8e4690PtHCnre2zzpuAX/LZJ3OA29z31XHOqMe5n28BotztexVILMS+i8X5Pr3lTnsBcBT4Euf3UBfYCZzjTn+5+x1q5W7z48Bcn/Wf9Ntw9/dO4Cyc7/ownN9EmM/vIxGoD1T053eLc2XxhhtvHJAC9PX5rRx34wzKvkyc33AGcG4e+z4GGOROGwV8BnyZ7X+zCeeYEAKE5rCMU44RnPw77oPPd97P33nW9+Emsn1/gBXAxT6fJwMPFfaYaVcop2co8JSq7lTVFOBJnIMEwNXAWFVdrqqH3XGFURn4FicJ3KxOXUgXoIaqPqWqx1R1PfA/4Bo/lzlWVdeo6hHgU5wfGcAQ4CtV/V5VjwMv4SSd7sDZOAf/V1X1uKpOAn7PYx0f4xwws1znDgPnB1wbaOgu62d1v9WFMEVVf1XVTFU9qqpzVHWp+3kJ8AlwjjvtZCAu60wZ5//5haqmAf2BDao6VlXTVXUhztn+YD9iiAG25TH+UmCtqo5zl/0JsAoY4I7PBNqKSEVV3aaqBS22ec29glnsxvEggKq+p6oH3O0bDZwpItE+8xVk32V52p12Bs5JyCfu72EL8DPQwZ1uOPCcqq5U1XTgn5y877O7Hfivqi5Q1Qx16gHScL5/J7ZTnSu/I/ntEBGpD/QE/uHGmwi8w5+/V4B5qvqlu73Zl1kVJ9Hk+n9V1d2q+rmqHlbVA8CznLq/3nePCenub8trHwDXw4mi2gv58/d52iyhnJ46OGfrWTa6w7LGbfYZd+K9/NniqiAVyWfjnCWO8TnoNsS5/E3NegGPArX8XOZ2n/eHgaw6iJO2S1Uz3fjruuO2ZDvw++6D7GYBFUXkLPfgEYdzIAenCGEdMMMt4nnYz7jz4rvPcdc72y2G2AeMwDlzx/3Rf8WfCfgaYLz7viFwVrZ9OxQ4w48YduMkytxk/97gfq6rqodwEvoIYJuIfCUiLf1Yp6/7VLWKqtZV1aGqmiIiwSIyRkSS3CKdDe601X3m83vf+djh8/5IDp+zvlMNgX/57Ms9gOB8p3LSEHgo2/6vz5+/r1PizUcdYI/7P8+yMdv681reXpxEn+v/VUQiROS/IrLR3cc/AVXk5Pqo/GLOwDlh8xWKc/JVFD4CBohIJZyT4J9VNa+TIb9YQjk9W3G++FkauMPAOZOp5zOuftYb/bPF1SkVyXmYgVNE9IOIZCWMzcAf7sEj6xWlqpec1tb86aTtEhFx49+Cs1113WFZGuS2IDcZfYpzlXIdMD3rR+2eLT+kqo1xzs4fFJG+hYw9+xXOx8BUoL6qRuMU0fjG/glwrTgVrhWB2e7wzcCP2fZtJVW9048YZgJXSO71Qdm/N+Dswy0Aqvqdqp6Pc/BahXPVmdO2FcR1wECgHxCNUzQCJ++Lgu67gtgMDM+2Pyuq6tw8pn822/QR7tVcbvHmZStQTUSifIad2Of5Lc8tZZiHU6SVm4eAFsBZqloZ6O0Oz2sfZ7eJP/83WRrx5wlIYb4Dp8zrXknOA67AuVobV4jln2AJJX+hIhLu8wrBORg9Lk5Fc3WcuoysyrFPgZtFpJWIRLjjCkVVX8D5kf/gru83YL9bOVnRPQttKyJdCrmqT4FLRaSviITi/FDScOqI5gHpwH0iEiJOBXbXfJb3Mc5Z91B8LqfdStembnLaj3N2FuhmzVE4Z6ZHRaQrzoHV19c4B/engIluAgSYDjQXkRvEaQgR6lZitiJ/L+MUUX4gf1Y81xWRl8WpWP7aXfZ17j4cglN/M11EaonTICISZ58f5M99sgOoJyIVTnM/pOFcPUXgFDn5M09e+64g3gIeEbchgIhEi8hVPuN3cHIl9f+AEe5VkohIpDiNBHwTgt9UdTPO9/c59/fbHriVP69I/fF34CYR+ZuIxLjbcaaITHDHR+FclaW6xUejTiPUiTjHlHoiEiROw5wBwCR3/A4gJltRpb9y+/58iLNt7fiz9KBQLKHk72ucL0vWazTwDBAPLAGWAgvdYajqN8BrOGe863AOxOD8qE+bqj6NU/E5E+dMcwBOMdIfOJXG77jDC7OO1Tjlqv92lzkAGODW0xwDrsSp4NuLkyi+yGd5C3DK1+vgtFLJ0szdjoM4++cNde+9EeeGrEcLsx2uu4CnROQATlL/NFtsaW78/fBJdu5V1AU4xWBbcYoHn8ep0M6TOq2ruuMUUyxw1/0DTqX3OlXdjVNH8xDOAf7vQH9V3YXzW3zIXecenDL4u9xFz8JpBrtdRHYVcD98iHOWuwWnIna+H/Pkue8KQlUn4+y/CW5x0DJObm47GicBp4rI1aoaj1OP8jrO92wdObe8Kohrcc7+t+IcOEep6vcF2Ia5wHnua72I7AHexjk2gNPQoSLOb2Y+Tp1nQT2Fk/h+wdnuF4ChqrrMjWEVzonsendf1cl1SafK7fszGeekarJb5FpoUvi6UJMX98x2GU4rlXSv4zHGmCziNLMerqozA7E8u0IpAiJyhTj3ilTFOTubZsnEGFOSiMggnPqVWYFapiWUojEcp617Ek45uD8VusYYUyxEZA7wJnC3T/1h4ZdrRV7GGGMCwa5QjDHGBERunauVedWrV9fY2FivwzDGmFIlISFhl6rWyGlcuU0osbGxxMfHex2GMcaUKiKSaw8ZnhR5icjT4vRMmihOb7d13OGx4vRIm+i+3vKZ51lxejc9mG1ZYSIyUZxeRBeISGwxb44xxhi8q0N5UVXbq2oczp3JvneTJ6lqnPsa4TN8GjnfmX0rsFdVm+I8/+H5ograGGNM7jxJKKq63+djJH70U6Oq83PpvGwgTs+Z4HRT0Ddbf1PGGGOKgWetvLKKsHD6efK9QmkkzsN9fhSRXn4sqi5uT57uzYP7cLoRN8YYU4yKLKGIyEwRWZbDayCAqj6mqvVxOmnLenreNqCBqnbAeZbDxyJSOb9V5TAsxyseEblDROJFJD4lJeX0NswYY0yOiqyVl6qe8hjbXHyM82yKUW6HfWnu/AluPzPNcTpizE0yThfryW5PwNE4nevlFNPbOJ260blzZ7uj0xhjAsirVl7NfD5ehvPsh6znjge77xvj9Eq7Pp/FTcV5TCg4T9WbpXb7vzHGFDuv7kMZIyItcJ6EthHniXDgPJjmKRFJx+kDa4TbJTgi8gLOcxkiRCQZeEdVRwPvAuNEZB3OlYm/j8E15Vh6Ria7Dh4j5UAaqUeOkXr4OAfT0jlyLIMjxzPIyFTSMxUBQoOF0OAgQoODqBQWQuWKIVQOD6VyxVBqVQ4nJrICQUHWDsSYctuXV+fOndVubCzb0tIzSNp5iLU7D7A+5RB/7DrE5r2H2bL3CCkH0wjUVz80WKgZFU6dKuHExkQSWz2SRtUjaV4rikbVIwm2ZGPKEBFJUNXOOY0rt3fKm7IlPSOTVdsPsHDTXpYk72Np8j6SUg6SnulkDRGoW6UiDapFcE7zGtSuUpGaUWHUiAqjWmQFoiuGEhUeQkRoCGGhztXI3HXOs4jOahzD8YxMjmdkcjAtnf1H0tl/9Diph4+xY38a2/cfZcf+oyTvPcKPa1L4LCH5RFwVQ4NpWTuKNnUq06F+VTrHVqVBtQisZbspiyyhmFIpI1NZkpzK3KTdzF+/m4SNezl8zHlibkxkBdrVi6Zf65q0OKMyLWpF0TAmgvDQ4AKt4/XZ6wDo1bwGFUKc6sYqERWgat7zHUxLZ8OuQ6zafoAVW/ezfOs+pizaykfzNwFQvVIYXWKr0qtZDXo1q079ahEF3HpjSiZLKKbUSD18jFmrdjJr1U5+XruLfUeOA9DyjCgGd6pHp4ZV6dSwKnWrVPT0CqBSWAht60bTtm40dHKGZWYqa3YeIH7DXhI27mX++t18s2w7ALExEfRpUZML25xBl9iqhARbJ+CmdLKEYkq0lANpfLt8O18v2cZvG/aQkalUrxRGv1a1OKdFDbo3iaF6pXwf9+65oCCh5RmVaXlGZa4/uyGqSlLKIX5em8JPa1L4+LdNvD93A1UjQunbqhYDzqxDjyYxllxMqWIJxZQ4h9LS+XbZdiYv2sLcpF1kKjSpEcmIcxpzQeszaFc3utS3qhIRmtasRNOalbi5RyMOpaXz05oUvlu+ne+Wb2dSQjLVK4Vx2Zl1uKJDXdrWrWz1LqbEs4RiSgRVZeGmvUz4bTNfLd3G4WMZ1K9Wkbv6NGXAmXVoXqtSmT6gRoaFcHG72lzcrjZHj2cwZ/VOJi/awkfzN/Ler3/Qpk5lrjurAQPj6lIpzH62pmSyZsPGUwfT0p0D57yNrN5xgMgKwQw4s86JOhEvk0hSivOkhCY1KnkWw77Dx5m6eAvjF2xi1XZn/1zeoS639GzkaVym/Mqr2bAlFOOJzXsO8/7cDUz8fTMH09JpW7cyN5zdkP7t6xBpZ+CnUFUWbU7l4wWbmLp4K8fSM+nbsia39mpEt8YxZfrqzZQsllByYAnFG8u27OPNH5P4Zuk2gkS4tH1tbuoeS1z9KiXuoDhzxQ4A+rWu5XEkJ9t1MI1x8zby0fyN7D50jDPrRXPPec3o16pmiduHpuyxhJIDSyjFK37DHl6btY6f1qQQFRbCdWc34KbusdSOruh1aLka8t95AEwc3s3jSHJ29HgGXyzcwls/JrFpz2Fa1a7Mvec15aI2Z5T6Rgum5LI75Y1n4jfs4eXv1zA3aTcxkRX4+0UtuP7shlQOD/U6tFIvPDSY685qwNWd6zElcSv/mb2Ou8YvpG3dyvz9wpb0albdrlhMsbKEYorE8q37eOm71cxenUL1ShV4/NJWXHdWAyIq2Fcu0EKCgxjUqR6Xd6jLlMQtvPz9Gm587ze6NY7hHxe3JK5+Fa9DNOWE/bpNQG3ec5j/m7GaLxO3El0xlH9c1JJh3RtaIikGwUHClR3rcWn72nyyYBP/nrWOy//zK1d0qMs/LmrJGdHhXodoyjj7lZuAOHD0OK/PXsfYXzYgAnf1acLwc5oQXdGKtopbWEgwN/VoxODO9Xlzzjr+9/MffLtsO3f2acIdvRsXuE8zY/xllfKmUDIzlUkJybzw3Wp2HUzjyo51+duFLUp0Zbu/tqYeAaBOldK9LZv3HOa5b1by9dLt1K9WkacHtqVPi5peh2VKKWvllQNLKIW3JDmVkVOWk7g5lU4NqzJqQGva16vidVgmF3OTdvHEl8tISjnEpe1rM7J/a2pVtmIwUzCWUHJgCeX07T96nJe+W824+RuJiQzj0UtackWHumWuRdG0xVsBGHBmHY8jCZy09Aze/nE9/569jrDgIB65pBXXdq1f5v53puhYs2ETMN8s3caoqctJOZjGsG6xPHhB8zLbBPij+RuBspVQwkKCubdvMwacWYfHvlzKo5OX8vXSbTx3ZTt7LospNOsb2/hl5/6jjBiXwJ3jF1IjKowpd/dg9GVtymwyKetiq0fy0a1n8c8r2rFo014uevUnxs3fSHktsTCBYVcoJk+qypeJWxg1ZTlH0zP5x0Utub1XI3tORxkgIlx3VgN6N6/OI18s5YkvlzFr5Q5eGHwmNaJK/jNmTMljRwWTq5QDadwxLoEHJi6mWa0ovr2/F3f2aWLJpIypVzWCD2/pypOXtWFu0m4uevUnfli5w+uwTClkRwaToxnLt3Phqz/x45oUHrukFZ8O70Zj6y69zBIRhnWPZdq9PalZOZxbP4hn5JRlHD2e4XVophSxVl7mJIePpfPUtBVM+H0zrWtX5l/XxNGsVpTXYXliz6FjAFSLrOBxJMUrLT2Dl75bzf9+dh7s9cbQjjSMifQ6LFNCWLPhHFhCOdWyLfu4b8Ii/th1iBHnNOGBfs2pEGIXseXVzBU7eOizxWRmKmMGtefS9rW9DsmUAHklFE+OFiLytIgsEZFEEZkhInXc4bEicsQdnigib7nDI0TkKxFZJSLLRWSMz7LCRGSiiKwTkQUiEuvFNpVmqsr7v/7BlW/M5VBaOuNvO4t/XNSy3CeTz+I381n8Zq/D8Ey/1rX46r6eNK5Zibs/XsiT05ZzPCPT67BMCebVEeNFVW2vqnHAdGCkz7gkVY1zXyN8hr+kqi2BDkAPEbnYHX4rsFdVmwKvAM8XQ/xlxr4jx7nzo4WMnraCXs2q8839venepLrXYZUIkxKSmZSQ7HUYnqpXNYLPhnfjpu6xjP11A9e/s4BdB9O8DsuUUJ4kFFXd7/MxEsiz3E1VD6vqbPf9MWAhUM8dPRD4wH0/CegrdtuvX5Zt2ceAf//CzJU7eOySVrwzrHO5qy8w+asQEsToy9rw8tVnkrg5lQH//oUlyaleh2VKIM/KNETkWRHZDAzl5CuURiKySER+FJFeOcxXBRgA/OAOqgtsBlDVdGAfEFOUsZcFn/6+mSvfnMux9EwmDu/G7b0bW/cbJk9XdqzH53d2J0iEwW/NY0riFq9DMiVMkSUUEZkpIstyeA0EUNXHVLU+MB64x51tG9BAVTsADwIfi0hln2WGAJ8Ar6nq+qzBOaw+xyseEblDROJFJD4lJSUwG1rKHEvP5NHJS/n750voEluVr+7rSaeGVb0Oy5QSbetGM/WeHsTVq8L9ExJ5+fs1dne9OaHI7pRX1X5+Tvox8BUwSlXTgDR3/gQRSQKaA1nNsd4G1qrqqz7zJwP1gWQ34UQDe3KJ6W13GXTu3Lnc/Qp27j/KneMXkrBxLyPOacLfLmxBsD173BRQTKUwxt3WlccmL+O1H9ayPuUgL111pj1nxXjT9YqINFPVte7Hy4BV7vAawB5VzRCRxkAzYL077hmcZHFbtsVNBYYB84DBwCy1U6ZTLElO5fYP49l/JJ3Xr+tA//Zlp8PDovL+zV29DqHECgsJ5sXB7WlasxLPf7uK5L1HeHdYZ2IqWZct5ZlXdShj3OKvJcAFwP3u8N7AEhFZjFPBPkJV94hIPeAxoDWw0G1SnJVY3gViRGQdTjHZw8W6JaXAlMQtXPXWPEKCgvjiru6WTPxUsUIwFSvYWXduRIQR5zThzaGdWLltP4PenMvG3Ye8Dst4yG5sLMNUlVdmruW1H9bSNbYab17f0c4gC2DcvA0A3NAt1tM4SoOEjXu49YN4gkV476YunFm/itchmSJS4m5sNEXv6PEM7p+QyGs/rOWqTvX46LazLJkU0PQl25i+ZJvXYZQKnRpW4/M7u1OxQjDXvD2f2at2eh2S8YAllDJoz6FjDH1nAVMXb+UfF7XkhcHty/1d76boNalRiS/u6k7jGpHc/mE8U90nXpryw44yZczG3YcY9OZclm7ZxxtDO3JnnyZ2f4kpNjWjwvnkjrPp2LAq909YxPgFG70OyRQjSyhlSOLmVK54Yy6ph4/xye1ncUk768zPFL/K4aF8eEtXzm1Rk8cmL+ONOeu8DskUE0soZcTs1Tu59u35RIYF8/md3enUsJrXIZlyLDw0mP/e0ImBcXV44dvVvPTdarsBshywRwCXAV8sTObvk5bQvFYU79/ShZpR4V6HVCZMHN7N6xBKtdDgIF65Oo6ICsG8PnsdxzMzefiillYEW4ZZQinl3vvlD56avoLuTWL47w2diAoP9TokY04IChKevbwdIUFB/PfH9RxPV57o38qSShllCaWUUlVe+X4Nr81ax0VtzuBf18YRFmI34QXS2z8lAXBH7yYeR1K6BQUJTw1sQ0iw8N6vf3A8I5OnBraxpFIGWUIphTIzlaemr+D9uRu4unM9/nlFO0KCrTos0H5Y6dxLYQml8ESEkf1bExocxNs/rSc4SBg1oLUllTLGEkopk5GpPPLFEj6NT+bWno14/FIrPjClg4jwyMUtychU3v3lD0KChMfs+1umWEIpRY5nZPLgp4uZtngr9/VtxgP9mtmP0ZQqIsLjl7bieEYm7/zyB6EhQfz9whb2PS4jLKGUEsfSM7nvk0V8u3w7D1/ckhHnWDGMKZ1EhNED2nA8Q3lzThJhIUH8pV9zr8MyAWAJpRRIS8/g7vELmblyJyP7t+aWno28DqlcsOd7FB2n9Vdbjmdk8urMtUSFh3Krfa9LPUsoJVxaegZ3fbSQH1bt5OmBbazn22L0wS32PJSiFBQkjLmyHYfS0nl6+gqiwkO4unN9r8MyhWBNg0ow32TyzOVtLZmYMickOIhXr4mjV7PqPPz5Er5dZr07l2aWUEqoY+mZ3D3+z2Ry/dkNvQ6p3HntB+dZMqZohYU43bR0aFCV+z5J5Je1u7wOyZwmSygl0PEMpwJ+5sqdPG3JxDO/rtvFr+vs4FYcIiqE8N5NXWhcI5Lh4+JZtmWf1yGZ02AJpYTJyFQe/HQx3y7fzsj+rbnBkokpJ6IrhvL+zV2pElGBm8b+zqbdh70OyRSQJZQSJDNTefjzJUxbvJWHL25prblMuXNGdDgf3NKF4xmZDBv7G7sPpnkdkikASyglhKry5LTlfJaQzP19m9l9Jqbcalozivdu6szW1CPc8v7vHD6W7nVIxk+WUEqIl2as5oN5G7mjd2P+0q+Z1+EYoGpEBapGVPA6jHKpU8Nq/PvaDizdso/7JySSkWnPUikNLKGUAP/9MYn/zE7i2q4NeORie15ESfHWDZ1464ZOXodRbl3Q5gye6N+a71fs4J9fr/Q6HOMHu7HRYxN+28Rz36yif/vaPHN5W0smxvi4uUcjNu4+zLu//EHDmAhutHuxSjRLKB76dtk2Hp28lD4tavDy1XEEB1kyKUme/3YVAP+4qKXHkZRvT/RvTfLew4yeupx6VStyXstaXodkcmFFXh6Zl7Sb+yYkEle/Cm8M7UiFEPtXlDQLN+5l4ca9XodR7gUHCf+6pgOt61Tm3o8XsXr7Aa9DMrnw5CgmIk+LyBIRSRSRGSJSxx0eKyJH3OGJIvKWzzzfishiEVkuIm+JSLA7PExEJorIOhFZICKxXmxTQazYup87PoynYbUI3rupCxEV7ELRmLxEhoXwzo1diAwL4dYPfrfmxCWUV6fFL6pqe1WNA6YDI33GJalqnPsa4TP8alU9E2gL1ACucoffCuxV1abAK8DzRR/+6du85zDDxv5GpfAQPrzVuYnLGJO/M6LDefvGzqQcSOPO8Qs5lp7pdUgmG08Siqru9/kYCeTbJtBnnhCggs88A4EP3PeTgL5SQmu29x46xrCxv5F2PIMPbulK7eiKXodkTKkSV78KLwxuz29/7GHklGWoWnPiksSzgnsReVZENgNDOfkKpZGILBKRH0WkV7Z5vgN2AgdwkgdAXWAzgKqmA/uAmFzWeYeIxItIfEpKSmA3KB9Hj2dw24fxJO89wjvDutC8VlSxrt8UXO3ocGpHh3sdhslmYFxd7j63CRN+38wHczd4HY7xIUWV4UVkJnBGDqMeU9UpPtM9AoSr6igRCQMqqepuEekEfAm08b2iEZFwYDzwlqp+LyLLgQtVNdkdnwR0VdXdecXXuXNnjY+PL+RW+iczU7n744V8u3w7r1/bkUvb1y6W9RpTVmVmKneMS2D26p2Mv+0szm6c4zmkKQIikqCqnXMaV2RXKKraT1Xb5vCakm3Sj4FB7jxpWYlAVROAJKB5tuUeBabiFHUBJAP1AUQkBIgG9hTVdp2O575ZyTfLtvPYJa0smRgTAEFBwitDzqRhTAR3j1/I1tQjXodk8K6Vl2/fIpcBq9zhNXxabzUGmgHrRaSSiNR2h4cAl2TNg5NchrnvBwOztAQVrI6bt4H//fwHN3WPtUecljJPTlvOk9OWex2GyUVUeChv39CZtPRM7vwogaPHM7wOqdzzqg5ljIgsE5ElwAXA/e7w3sASEVmMU0cyQlX34FTcT3WnX4xTj5LVpPhdIEZE1gEPAg8X43bkafbqnYyaupx+rWryRP/Wdhd8KbNi635WbN2f/4TGM01rVuLlq89kcfI+Hv/SKum9lucNECKylDxaYKlq+9NZqaoOymX458DnOQzfAXTJZZ6j/NmEuMRYuW0/94xfSKvalfnXNR3sLnhjisgFbc7gvr7NeO2HtXRoUIWhZ9kzhLyS3x11/d2/d7t/x7l/hwL29JtcpBxI47YP4qkUHsK7w5ybsYwxRecvfZuxeHMqT05dQbu60bSvV8XrkMqlPIu8VHWjqm4Eeqjq31V1qft6GLiweEIsXY4ez+COcfHsOXSMd4d14QxrdmpMkQsKEl4dEkf1ShW486OFpB4+5nVI5ZK/dSiRItIz64OIdMep1zA+VJV/fL6ERZtSeWXImbStG+11SKYQGteIpHEN+5qXFlUjK/DG9Z3YeeAoD0xMJNOeoVLs/C2LuRV4T0SyjpCpwC1FElEp9sacJKYkbuVvF7bgorbWPLi0e+7K06oiNB6Kq1+FJ/q3ZuSU5bwxZx33nGcPqytOfiUU956QM0WkMs7NkPuKNqzS5/sVO3hpxmoGxtXhrj72+F5jvHLD2Q2J37CXl79fQ+fYanbTYzHyq8hLRKJF5GVgFvCDiPyfz9VKubd6+wH+MmER7epG8/yg9tY8uIx45IslPPLFEq/DMAUkIvzzynY0jInk/gmLrGfiYuRvHcp7OP1nXe2+9gNjiyqo0iT18DFu/zCeiLAQ3r6hM+GhwV6HZAJkfcoh1qcc8joMcxoqhYXw+nUd2Hv4OA99ttjqU4qJvwmliaqOUtX17utJoHFRBlYapGdkcu8ni9i+7yj/vaGTtegypgRpUyeaJy5txZzVKfzv5/Veh1Mu+JtQjmRr5dUDKPed57zw3Wp+XruLpy9vQ8cGVb0OxxiTzfVnN+Titmfw4nerWbjJnr5Z1PxNKHcC/xGRDSKyEXgdGF50YZV8Uxdv5e2f1nPD2Q0Z0qWB1+EYY3IgIowZ1J4zosO575NF7D963OuQyjS/EoqqJrpPS2wPtFPVDqpabmsrV23fzz8mLaFzw6o80b+11+GYItK6TmVa16nsdRimkKIrhvKvazqwbd9RRn65zOtwyjS/mg27LbpG4XTeiIj8CDxVHpsP7zt8nOHjEogKD+GNoR2pEOLZM8pMERs1oI3XIZgA6dSwKvf3bcbL36/hnBY1uKJDPa9DKpOslVcBvf1zEltTj/Dm9R2pWdkq4Y0pLe4+tyldYqvyxJfL2bTbuiIsCn49sVFEElU1Lr9hpcnpPrHxeEYmizal0rVRtSKIypQkf5mwCIBXr+ngcSQmUJL3Hubif/1M05qV+HR4N0KDrYShoALxxEZr5eUKDQ6yZFJObNt3lG37jnodhgmgelUjeO7KdizalMrrs9Z5HU6Z429fXiOAD926FMF5xO5NRRWUMcYUlf7t6zBr5U5en72Oc1vWJK5+Fa9DKjP8beW1OIdWXouLNjRjjCkaowe2oVZUGA9OTOTIMXt0cKD425dXmIhcB9wD/EVERorIyKINzRhjikbl8FBeuvpM1u86xHPfrPQ6nDLD3zqUKcBAIB045PMypszq2LAqHRtaDwhlVfcm1bm1ZyM+nLeRH9ekeB1OmeBvK69lqtq2GOIpNqfbyssYU3YcPZ7BgH//wr4jx5nxQG+qRFTwOqQSLxCtvOaKSLsAxmSMMZ4LDw3mlSFx7Dl0jCenrfA6nFIvz4QiIktFZAnQE1goIqtFZInPcGPKrBHjEhgxLsHrMEwRa1s3mrvPbcrkRVv4bvl2r8Mp1fJrNty/WKIwpgTae/iY1yGYYnL3uU35fsUOHpu8lC6x1agWaUVfpyO/Iq+9qroRp9uVnF7GGFPqVQgJ4qWrzmTfkeOMmrrc63BKrfwSysfu3wQg3v2b4PP5tIjI027RWaKIzBCROu7wWBE54g5PFJG3cph3qogs8/kcJiITRWSdiCwQkdjTjcsYU361rlOZe89rxrTFW/lm6TavwymV8kwoqtrf/dtIVRu7f7NehXli44uq2t7tC2w64HtPS5KqxrmvEb4ziciVwMFsy7oV50qqKfAK8Hwh4jLGlGN39mlC27qVefzLZew9ZEWeBZVfpXzHvF6nu1JV3e/zMRLIt+2yiFQCHgSeyTZqIPCB+34S0FdE5HRjMyZLj6bV6dG0utdhmGIUGhzEC4Ocoq+nplurr4LKr1L+//IYp8B5p7tiEXkWuBHYB5zrM6qRiCzC6SL/cVX92R3+tBtP9n6n6wKbAVQ1XUT2ATHArhzWeQdwB0CDBvaURZO3+/o28zoE44HWdSpzV58mvDZrHZedWYdzW9b0OqRSw68bG09rwSIzgTNyGPWYqk7xme4RIFxVR4lIGFBJVXeLSCfgS6AN0Bh4WlUHuHUk07NutBSR5cCFqprsfk4Cuqrq7rzisxsbjTG5SUvPoP9rv3AwLZ0ZD/QmKjzU65BKjELf2CgiESLyuIi87X5uJiJ5NilW1X6q2jaH15Rsk34MDHLnSctKBKqaACQBzYFuQCcR2QD8AjQXkTnu/MlAfTeuECAapzdkYwpl2Hu/Mey937wOw3ggLCSY5we3Z/v+ozz/7Sqvwyk1/L1TfixwDOjufk7m1LoMv4mIb1nCZcAqd3gNEQl23zcGmgHrVfVNVa2jqrE4N1muUdU+7vxTgWHu+8HALC2qyy5Trhw9nsHR49YTbXnVsUFVbu7eiI/mb2LB+jwLPIzL34TSRFVfAI4DqOoRnOeinK4xIrLMvdv+AuB+d3hvYImILMapYB+hqvldbbwLxIjIOpxK+4cLEZcxxpzw1wubU79aRR6ZvNROLvzg7wO2jolIRdzWWCLSBEg73ZWq6qBchn8OfJ7PvBuAtj6fjwJXnW4sxhiTm4gKITxzeTuGvfcbb8xJ4sHzm3sdUonm7xXKKOBboL6IjAd+AP5eZFEZY0wJcU7zGgyMq8Obc9axbqd1EJIXfxNKAnAlzmN/PwE6AxuLKCZjSoS+rWrSt5U1GTXwRP/WRFQI4dEvlpGZaVW0ufE3oUwDjqvqV6o6HajhDjOmzLqjdxPu6N3E6zBMCVC9UhiPXdKK3zbsYWL8Zq/DKbH8TSj/BKaJSKR7f8gk4PqiC8sYY0qWqzrX4+zG1Xju65XsPHDU63BKJL8Siqp+hdNP1vfA+8DlqppYdGEZ470h/53HkP/O8zoMU0KICM9e0Y6jxzP551f2HPqc5NnKS0T+zcn9bFUG1gP3igiqel9RBmeMMSVJkxqVGH5OY/49ax1Xd6lP9ybW15uv/JoNZ++bxB5fZ4wp1+4+tylTErfyxJfL+Ob+3lQI8bfmoOzLM6Go6gd5jTfGmPImPDSYJwe24eaxv/O/n9dz97lNvQ6pxMiv+/pP3b9L3QdinfQqnhCNMaZkObdFTS5uewav/bCWzXuyd4BefuVX5JXVJYo9W96UO/3b1/Y6BFOCPdG/NT+uSWHU1OW8d1MXr8MpEfIr8trm/j3lJkYR+RXoUURxGeO5G7rFeh2CKcHqVKnIX/o1459fr+KHlTvo26qW1yF5rjC1SfaEKlOmHTmWwZFj1iGgyd3NPRrRtGYlnpy2wjqPpHAJxfofMGXaTWN/46ax9jwUk7vQ4CCevKwNm/Yc5n8/rfc6HM/ldx/KlbmNAioGPhxjjCldejStzqXtavOfOeu4omNd6lWN8Dokz+RXKT8gj3HTAxmIMcaUVo9e2opZq3byzPSVvHVDJ6/D8Ux+lfI3F1cgxhhTWtWtUpF7zmvKi9+t5qc1KfRuXsPrkDxR4DoUEbErE2OMyea2Xo2IjYngyWnLOZ6R6XU4njidSvm6AY/CmBJocKd6DO5Uz+swTCkRFhLM45e2JinlEB/NL5+Pi/L3EcC+FgU8CmNKoKs61/c6BFPK9G1Vk17NqvPK92sYGFeXapEVvA6pWBX4CkVVbymKQIwpafYcOsaeQ8e8DsOUIiLCyP6tOXQsg5e/X+11OMXOr4SSS19eP4vIKyISU9RBGuOFOz9K4M6PrINtUzDNakVxw9kN+XjBJlZu2+91OMXK3yuUb4CvgKHuaxrwE7Ad54FbxhhjXA/0a050xVCemrYC1fJzD7i/CaWHqj6iqkvd12NAH1V9HogtuvCMMab0iY4I5cELWjBv/W6+W77d63CKjb8JpZKInJX1QUS6ApXcj+kBj8oYY0q5a7vUp3mtSjz3zSqOpZePZsT+JpTbgHdE5A8R2QC8A9wmIpHAcwVdqYg87dbDJIrIDBGp4w6PFZEj7vBEEXnLZ545IrLaZ1xNd3iYiEwUkXUiskBEYgsajzHGBFpIcBCPXdqajbsP8+G8DV6HUyz8ajasqr8D7UQkGhBVTfUZ/elprPdFVX0CQETuA0YCI9xxSaoal8t8Q1U1+2OJbwX2qmpTEbkGeB4YchoxGXOS689u6HUIppQ7p3kNzmleg9d+WMugjvWoWsabEfvbyitaRF4GfgBmisj/ucnltKiqb9OHSArXc/FAIOtRxZOAviIihVieMQAMOLMOA86s43UYppR77NJWHExL518/rPU6lCLnb5HXe8AB4Gr3tR8YW5gVi8izIrIZp9XYSJ9RjURkkYj8KCK9ss021i3uesInadQFNgOoajqwD8ixKbOI3CEi8SISn5KSUpjwTTmwNfUIW1OPeB2GKeWa14ri2q4N+Gj+RpJSDnodTpHyN6E0UdVRqrrefT0JNM5rBhGZKSLLcngNBFDVx1S1PjAeuMedbRvQQFU7AA8CH4tIZXfcUFVtB/RyXzdkrSqH1ed4xaOqb6tqZ1XtXKNG+ey8zfjvgYmJPDAx0eswTBnwwPnNCQ8N5rmvV3odSpHyN6EcEZGeWR9EpAeQ56mbqvZT1bY5vKZkm/RjYJA7T5qq7nbfJwBJQHP38xb37wF3nq7u/MlAfTeuECAa2OPndhljTJGrXimMu85twsyVO5mXtNvrcIqMvwllBPAfEdngtvJ6HRh+uisVkWY+Hy8DVrnDa4hIsPu+MdAMWC8iISJS3R0eCvQHlrnzTwWGue8HA7O0PN1JZIwpFW7p0Yja0eE8981KMjPL5iHKr4SiqotV9UygPdDeLZI6rxDrHeMWfy0BLgDud4f3BpaIyGKcCvYRqroHCAO+c6dPBLYA/3PneReIEZF1OMVkDxciLmOMKRLhocE8dEELliTv46ul27wOp0gUqLfhbK2zHgRePZ2VquqgXIZ/Dnyew/BDQI6PQVPVo8BVpxOHMcYUpys61OXdX/7ghe9WcUGbWoSFBHsdUkCdzvNQsljTXFOm3d6rMbf3yrPtiTEFEhwkPHJxSzbvOcL4+Zu8DifgCpNQymYhoDGufq1r0a91La/DMGVM7+Y16NWsOv+etZZ9R457HU5A5ZlQROSAiOzP4XUAsDu+TJmWlHKwzN83YLzxj4taknrkOG/OSfI6lIDKM6GoapSqVs7hFaWqp/O0R2NKjUe/WMqjXyz1OgxTBrWtG83lcXUZ++sfbN931OtwAqYwRV7GGGNO04PnNydTtUx1yWIJxRhjPFC/WgRDz2rIp/GbWV9GilYtoRhjjEfuPrcpYSFB/N+MNV6HEhCWUIwxxiM1osK4rVdjvlq6jSXJqV6HU2iWUIzJxb3nNePe85rlP6ExhXB7r0ZUjQjlhW9Xex1KoVlCMSYXPZtVp2ez6l6HYcq4qPBQ7j63Kb+s28Uva3d5HU6hWEIxJhfLt+5j+dZ9XodhyoHrz25InehwXpyxmtLct60lFGNy8dS0FTw1bYXXYZhyIDw0mPv6NmPx5lRmrtzpdTinzRKKMcaUAIM61SM2JoL/m7G61HZvbwnFGGNKgNDgIB44vzmrth9geint3t4SijHGlBD929ehea1KvPr9GtIzMr0Op8AsoRhjTAkRHCQ8eH4L1u86xBeLtngdToFZB4/G5OLvF7XwOgRTDl3Yphbt60Xzr5lrGRhXp1Q9hMuuUIzJRaeG1ejUsJrXYZhyRkR46IIWbEk9wqfxyV6HUyCWUIzJRcLGPSRs3ON1GKYc6t2sOp0aVuWN2es4ejzD63D8ZgnFmFy88O3qMtEdhil9RIQHz2/Otn1Hmfj7Zq/D8ZslFGOMKYG6N4mha2w13phTeq5SLKEYY0wJJCI8cH5zduxP4+MFm7wOxy+WUIwxpoTq1iSGbo1jeGNOEkeOlfyrFEsoxhhTgj1wfnN2HUxj/IKNXoeSL08Siog8LSJLRCRRRGaISB13eKyIHHGHJ4rIWz7zVBCRt0VkjYisEpFB7vAwEZkoIutEZIGIxHqxTabsGTmgNSMHtPY6DFPOdW1UjZ5Nq/PWjyX/KsWrK5QXVbW9qsYB04GRPuOSVDXOfY3wGf4YsFNVmwOtgR/d4bcCe1W1KfAK8HzRh2/KgzZ1omlTJ9rrMIzhL/2asevgsRJ/leJJQlHV/T4fIwF/uta8BXjOnT9TVbOeRDMQ+MB9PwnoKyISqFhN+fXL2tL/wCNTNnSOrUb3JjH896f1JbrFl2d1KCLyrIhsBoZy8hVKIxFZJCI/ikgvd9oq7rinRWShiHwmIrXcYXWBzQCqmg7sA2JyWecdIhIvIvEpKSlFsFWmLPn3rLX8e9Zar8MwBoD7+jYj5UAan/xWclt8FVlCEZGZIrIsh9dAAFV9TFXrA+OBe9zZtgENVLUD8CDwsYhUxulzrB7wq6p2BOYBL2WtKofV53jFo6pvq2pnVe1co0aNgG2rMcYUtbMbx3BWo2q89WNSib1KKbKEoqr9VLVtDq8p2Sb9GBjkzpOmqrvd9wlAEtAc2A0cBia783wGdHTfJwP1AUQkBIgGrL8MY0yZc3/fZuzYn8an8SXz7nmvWnk18/l4GbDKHV5DRILd942BZsB6dR6yPA3o487TF8h6NutUYJj7fjAwS0vzQ5mNMSYX3ZrE0LlhVd6ck0Raesm7SvGqDmWMW/y1BLgAuN8d3htYIiKLcSrYR6hq1tXGP4DR7jw3AA+5w98FYkRkHU4x2cPFtRHGGFOcRIT7+zVj276jfFYCeyKW8noy37lzZ42Pj/c6DFOCJaUcBKBJjUoeR2LMn1SVK96YS8qBNOb8rQ+hwcV7XSAiCaraOadxdqe8MbloUqOSJRNT4ogI957XlC2pR5iSuNXrcE5iCcWYXMxcsYOZK3Z4HYYxpzivZU1a1a7MG3PWkZFZckqZLKEYk4v//bye//283uswjDmFiHD3uU1Yn3KIb5Zt8zqcE+yZ8j6OHz9OcnIyR48e9ToUUwLc3aEiACtXrvQ4klOFh4dTr149QkNDvQ7FeOTitrVpXGMN/5mdxKXtalMSOgixhOIjOTmZqKgoYmNjS8Q/x3irQgmtlFdVdu/eTXJyMo0aNfI6HOOR4CDhrj5N+etni5m1aid9W9XKf6YiZkVePo4ePUpMTIwlE1OiiQgxMTF2JW0YGFeHelUr8u9Z6ygJLXYtoWRjycSUBvY9NQChwUGMOKcJiZtTmZu02+twLKEYk5v6VSOoXzXC6zCMydPgTvWoERXGm3OSvA7FEkpJU6lS4Mvrb7rpJiZNmnTSsK1btzJ48GAA3n//fe65556cZs1Rnz59yLop9JJLLiE1NZUNGzbQtm3bwAXtKqrl+qNCSBAVQuwnYkq28NBgbu3ZiF/W7WJJcqqnsdivpZyqU6fOKUnmdHz99ddUqVKl8AGVQKmHj5F6+JjXYRiTr6FnNSAqPMTzqxRr5ZWLJ6ctZ8XW/flPWACt61Rm1IA2BZ4vMTGRESNGcPjwYZo0acJ7771H1apV+f3337n11luJjIykZ8+efPPNNyxbtsyvZW7YsIH+/fufMv1XX33FM888w7Rp01i4cCGjRo0iLS2NJk2aMHbs2FOuoGJjY09crWRkZHD77bczd+5c6taty5QpU6hYsWKu8ec2PCEhgVtuuYWIiAh69uxZ4P0VKLsPOcmkSkQFz2Iwxh9R4aHc2K0hb8xJIinloGctE+0KpRS48cYbef7551myZAnt2rXjySefBODmm2/mrbfeYt68eQQHBxd6PZMnT2bMmDF8/fXXADzzzDPMnDmThQsX0rlzZ15++eU851+7di133303y5cvp0qVKnz++ed5xp/Xdr322mvMmzev0NtkTHlxc49GVAgO4r8/eneVYlcouTidK4misG/fPlJTUznnnHMAGDZsGFdddRWpqakcOHCA7t27A3Ddddcxffr0017P7NmziY+PZ8aMGVSuXJnp06ezYsUKevToAcCxY8fo1q1bnsto1KgRcXFxAHTq1IkNGzbkGr+/w2+44Qa++eab094uY8qL6pXCGNKlPp/8tokHzm9O7eiKxR6DXaGUUnm1Ob/55puJi4vjkksu8Xt5jRs35sCBA6xZs+bE8s8//3wSExNJTExkxYoVvPvuu3kuIyws7MT74OBg0tPT/V5/FlW1JrHGnKbbezUmU+Gdn//wZP2WUEq46Ohoqlatys8//wzAuHHjOOecc6hatSpRUVHMnz8fgAkTJpyYZ+zYsSQmJp4ouvJHw4YN+eKLL7jxxhtZvnw5Z599Nr/++ivr1q0D4PDhwyeSTSDiz214lSpViI6O5pdffgFg/PjxBV6nMeVV/WoRXHZmHT75bZMnDUqsyKuEOXz4MPXq1Tvx+cEHH+SDDz44UXnduHFjxo4dC8C7777L7bffTmRkJH369CE6OjrX5Q4fPpy//OUvANSvX59PPvnklGlatGjB+PHjueqqq5g2bRrvv/8+1157LWlpaYBTp9K8efMCb1Nu8ec2fOzYsScq5S+88MICry9QGlaze1BM6TP8nMZMXrSFj+Zv5J7zmuU/QwDZA7Z8rFy5klatWnkUUcEdPHjwRKurMWPGsG3bNv71r395HJUpLqXt+2qKz01jf2PZln388o/zCA8tfIMdX/aArTLqq6++Ii4ujrZt2/Lzzz/z+OOPex1SmbLn0DH2HLL7UEzpM7x3E3YdPMbnC4v3McFW5FWKDRkyhCFDhngdRpm11y2DrhZp96GY0uXsxtVoXy+ad37+g2u6NCA4qHgautgVijHGlDEiwvDeTfhj1yG+X7G92NZrCcUYY8qgi9qeQYNqEbz14/pi69reEooxxpRBwUHC7b0akbg5ld837C2WdVpCMcaYMmpwp/pUi6xQbN2xWEIpYYKDg4mLizvxGjNmTK7Tfvnll6xYseLE55EjRzJz5sxCx5Camsobb7xR4PlGjx7NSy+9lOPwunXrnmiRNnXq1ELHGAj//Oc/8xzfKCaSRjGRuY7Puk/H165du6hRo8aJe3dymqcgjwowpjAqVgjmhrMb8sOqnazbebDI1+dJQhGRp0VkiYgkisgMEanjDo8VkSPu8EQRecsdHuUzLFFEdonIq+64MBGZKCLrRGSBiMR6sU2BktU7b9br4YcfznXa7Anlqaeeol+/foWO4XQTSl4eeOABEhMT+eyzz7jlllvIzMz0a76MjIyAxuErv4QSFCQEZWsd4xvPlVdeyffff8/hw4dPDJs0aRKXXXbZSd3QGOOlG7o1pEJIEO/+UvTdsXh1hfKiqrZX1ThgOjDSZ1ySqsa5rxEAqnrAZ1gcsBH4wp3+VmCvqjYFXgGeD1SQQ/4775TXuHkbADhyLCPH8Z/FbwacexiyjyuMhx9+mNatW9O+fXv++te/MnfuXKZOncrf/vY34uLiSEpKOulBWrGxsTz66KN069aNzp07s3DhQi688EKaNGnCW2+9BTg3Rvbt25eOHTvSrl07pkyZcmJdSUlJxMXF8be//Q2AF198kS5dutC+fXtGjRp1Iq5nn32WFi1a0K9fP1avXp3vdrRq1YqQkBB27drF5ZdfTqdOnWjTpg1vv/32iWkqVarEyJEjOeuss5g3bx5PPfUUXbp0oW3bttxxxx0nKhj79OnDAw88QO/evWnVqhW///47V155Jc2aNTvpnpyPPvqIrl27EhcXx/Dhw8nIyODhhx/myJEjxMXFMXTo0Byn27nvMLsPpp0ST5bKlSvTu3dvpk2bdmLYhAkTuPbaa5k2bRpnnXUWHTp0oF+/fuzYseOUfZH9wWe+jwbIbX8bU1DVK4UxqGNdvliYzO6DOV85B4onCUVVfR80Egn43QRBRJoBNYGf3UEDgQ/c95OAvlKKexfMOshlvSZOnMiePXuYPHkyy5cvZ8mSJTz++ON0796dyy67jBdffJHExESaNGlyyrLq16/PvHnz6NWr14mD1/z58xk50snf4eHhTJ48mYULFzJ79mweeughVJUxY8bQpEkTEhMTefHFF5kxYwZr167lt99+IzExkYSEBH766ScSEhKYMGECixYt4osvvuD333/Pd/sWLFhAUFAQNWrU4L333iMhIYH4+Hhee+01du92nol96NAh2rZty4IFC+jZsyf33HMPv//+O8uWLePIkSMn9apcoUIFfvrpJ0aMGMHAgQP5z3/+w7Jly3j//ffZvXs3K1euZOLEifz6668kJiYSHBzM+PHjGTNmzImrwfHjx+c43YfjPiL1yPFT4vF17bXXnuhHbevWraxZs4Zzzz2Xnj17Mn/+fBYtWsQ111zDCy+84Pd3ILf9bczpurVnY9LSMxk3f2ORrsezGxtF5FngRmAfcK7PqEYisgjYDzyuqj9nm/VaYKL+2Q6uLrAZQFXTRWQfEAPsymGddwB3ADRo0CDfGCcOz7279ooVgvMcXy2yQp7jc12ue5DzlZ6eTnh4OLfddhuXXnop/fv392tZl112GQDt2rXj4MGDREVFERUVRXh4OKmpqURGRvLoo4/y008/ERQUxJYtW3I8k54xYwYzZsygQ4cOgHNls3btWg4cOMAVV1xBRETESevLySuvvMJHH31EVFQUEydORER47bXXmDx5MgCbN29m7dq1xMTEEBwczKBBg07MO3v2bF544QUOHz7Mnj17aNOmDQMGDDhlG9u0aUPt2rUBp/fkzZs388svv5CQkECXLl0AJ2HXrFnzlPh++OGHU6YLiawCcEo8vvr3789dd93F/v37+fTTTxk8eDDBwcEkJyczZMgQtm3bxrFjx2jUqFGu+ya73PZ37969/V6GMb6a1qzEeS1rMm7eRkac0yTg3bFkKbKEIiIzgTNyGPWYqk5R1ceAx0TkEeAeYBSwDWigqrtFpBPwpYi0yXZFcw1wg++qclhHjlc8qvo28DY4fXkVeKM8EhISwm+//cYPP/zAhAkTeP3115k1a1a+82WV4wcFBZ1Uph8UFER6ejrjx48nJSWFhIQEQkNDiY2N5ejRo6csR1V55JFHGD58+EnDX331Vb+7mn/ggQf461//euLznDlzmDlzJvPmzSMiIoI+ffqcWHd4ePiJB4YdPXqUu+66i/j4eOrXr8/o0aNPijG/bVRVhg0bxnPPPZdnfDlNl5Ry8JR4sqtYsSIXXXQRkydPZsKECbzyyisA3HvvvTz44INcdtllzJkzh9GjR58yb0hIyIm6JFXl2LFjJ97ntL+NKYzbejXiuv8tYPKiLVzbNf8T6tNRZEVeqtpPVdvm8JqSbdKPgUHuPGmqutt9nwAkASe6txWRM4EQd1yWZKC+Oz4EiAb2FNV2eeHgwYPs27ePSy65hFdfffXEFUxUVBQHDhw47eXu27ePmjVrEhoayuzZs9m4cWOOy73wwgt57733OHjQOcBu2bKFnTt30rt3byZPnsyRI0c4cODASXUJ/qy7atWqREREsGrVqhPd8GeXlTyqV6/OwYMHT6pz8Effvn2ZNGkSO3fuBGDPnj0ntjM0NJTjx4/nOt2WzZv8Wse1117Lyy+/zI4dOzj77LNPbF/dunUBp1flnMTGxpKQ4HyVp0yZciKW3Pa3MYXRrXEMbepU5p2f15OZWTTn01618vLtU/kyYJU7vIaIBLvvGwPNgPU+014LZO93fSowzH0/GJjlUxxW6mSvQ3n44Yc5cOAA/fv3p3379pxzzjknzoKvueYaXnzxRTp06EBSUsHbmQ8dOpT4+Hg6d+7M+PHjadmyJQAxMTH06NGDtm3b8re//Y0LLriA6667jm7dutGuXTsGDx7MgQMH6NixI0OGDCEuLo5BgwbRq1cvv9d90UUXkZ6eTvv27XniiSdOHIizq1KlCrfffjvt2rXj8ssvP1Ek5a/WrVvzzDPPcMEFF9C+fXvOP/98tm3bBsAdd9xB+/btGTp0aI7T7dzhX5cVF1xwAVu3bmXIkCEnrthGjx7NVVddRa9evahevXqO891+++38+OOPdO3alQULFhAZGXlieTntb2MKQ0S4vVdjklIOMWdN0ZygeNJ9vYh8DrQAMnFabI1Q1S0iMgh4CkgHMoBRqjrNZ771wCWquspnWDgwDuiAc2Vyjar6JqEclYXu6035Zt9XU1DHMzIZPi6BW3o0omeznE908pNX9/WeVMqrao41nKr6OfB5HvM1zmHYUeCqwEVnjDFlU2hwEO/dVLCr/IKwO+WNMcYEhCWUbEpx9YspR+x7akoiSyg+wsPD2b17t/1YTYmmquzevZvw8HCvQzHmJPbERh/16tUjOTmZlJQUr0MxJk/h4eHUq1fP6zCMOYklFB+hoaEFuqPZGGPMn6zIyxhjTEBYQjHGGBMQllCMMcYEhCd3ypcEIpKCc5f+6ahODr0Zl3G2zeWDbXP5UJhtbqiqNXIaUW4TSmGISHxuXQ+UVbbN5YNtc/lQVNtsRV7GGGMCwhKKMcaYgLCEcnrezn+SMse2uXywbS4fimSbrQ7FGGNMQNgVijHGmICwhGKMMSYgLKH4QUSuEpHlIpIpIrk2tRORi0RktYisE5GHizPGQBORaiLyvYisdf9WzWW6B9x9s0xEPnGfoFkqFWCbq4jIJBFZJSIrRaRbcccaKP5uszttsIgsEpHpxRljoPmzzSJSX0Rmu//f5SJyvxexFkZ+xyNxvOaOXyIiHQu7Tkso/lkGXAn8lNsEIhIM/Ae4GGgNXCsirYsnvCLxMPCDqjYDfnA/n0RE6gL3AZ1VtS0QDFxTrFEGVr7b7PoX8K2qtgTOBFYWU3xFwd9tBrif0r2tWfzZ5nTgIVVtBZwN3F2afs9+Ho8uBpq5rzuANwu7XksoflDVlaq6Op/JugLrVHW9qh4DJgADiz66IjMQ+MB9/wFweS7ThQAVRSQEiAC2Fn1oRSbfbRaRykBv4F0AVT2mqqnFFF9R8Ov/LCL1gEuBd4onrCKV7zar6jZVXei+P4CTSOsWV4AB4M/xaCDwoTrmA1VEpHZhVmoJJXDqApt9PidTur6A2dVS1W3g/LiAmtknUNUtwEvAJmAbsE9VZxRrlIGV7zYDjYEUYKxb/POOiEQWZ5AB5s82A7wK/B3ILKa4ipK/2wyAiMQCHYAFRR9awPhzPAr4Mcueh+ISkZnAGTmMekxVp/iziByGleg22Xlts5/zV8U5y2kEpAKficj1qvpRwIIMsMJuM85vpiNwr6ouEJF/4RSZPBGgEAMuAP/n/sBOVU0QkT4BDK3IBOD/nLWcSsDnwF9UdX8gYism/hyPAn7MsoTiUtV+hVxEMlDf53M9SnjxT17bLCI7RKS2qm5zL4N35jBZP+APVU1x5/kC6A6U2IQSgG1OBpJVNetsdRJ51zt4LgDb3AO4TEQuAcKByiLykapeX0QhF1oAthkRCcVJJuNV9YsiCrWo+HM8Cvgxy4q8Aud3oJmINBKRCjiV01M9jqkwpgLD3PfDgJyu0jYBZ4tIhIgI0JfSXWmb7zar6nZgs4i0cAf1BVYUT3hFwp9tfkRV66lqLM73elZJTiZ+yHeb3e/zu8BKVX25GGMLFH+OR1OBG93WXmfjFFlvK9RaVdVe+byAK3CyeRqwA/jOHV4H+NpnukuANUASTlGZ57EXYptjcFrArHX/Vstlm58EVuG0hBsHhHkdezFscxwQDywBvgSqeh17UW+zz/R9gOlex13U2wz0xCn+WQIkuq9LvI69gNt5yvEIGAGMcN8LTkuwJGApTmvNQq3Tul4xxhgTEFbkZYwxJiAsoRhjjAkISyjGGGMCwhKKMcaYgLCEYowxJiAsoZiAEZEYEUl0X9tFZIvP5woBXlef3Hq9FZGuIvKT29PqKrd7lIgCLj9WRK4LTLSnLLuziLzmvu8jIt0LsaxOIrLU7TH2Nff+iZyme8SdZrWIXOgz/FkR2SwiB/NZz8UiEu/2vrtKRF5yh48Wkb9mm3aDiFR332f4fAcS3W5Msi+7tu//srD/PxGpISLf+ju9CRy7U94EjKruxrlHAxEZDRxU1ZeyxotIiKqmF2UMIlIL+Ay4RlXnuQfYQUAUcLgAi4oFrgM+DnSMqhqPcx8LOPd1HATmnubi3sTpKXY+8DVwEfCN7wRuL7PXAG1w7rWYKSLNVTUDmAa8jnNPRo5EpK07zaWqusrtCPQOP+M7oqpx+UzzIPA/d12F+v+537EUEdkmIj1U9Vc/4zQBYFcopkiJyPsi8rKIzAaed88+57odK87NuuNcRBaISBuf+ea4Z9+RIvKeiPzuzpNfD853Ax+o6jwAdUxS1R3iPAfjS3Ge/TBfRNq76zrH5wx6kYhEAWOAXu6wB/LYvlgRWebz+a9uMs3ahudF5DcRWSMivdzhfURkunu2PgJ4wF1PL3GevbNMRBaLSK6PS3CXUxuorKrz1Lmh7ENy7i14IDBBVdNU9Q9gHU5vtKjqfM3/7ui/A8+q6ip3nnRVfSOfeQpiEJB1RZHX/y+3785NIvKZiEwDsjon/RIYGsAYjR/sCsUUh+ZAP1XNELf7d1VNF5F+wD9xDigTgKuBUe6Bso46nRH+E6erj1tEpArwmzgd/+WmLX92TZ7dk8AiVb1cRM7DOQDHAX8F7lbVX8XpDPAoTv9cf1XV/oXc9hBV7SpOP1ijcPo/A0BVN4jIW/hcyYnIUuBCVd3ibi8iUgd4R1Uvybbsujg9OGTJrbfYujhXMPlNl5u2wP/lMf4BEfHtiqWOz/uKIpLovv9DVa/wnVFEGgF7VTXNZ125/f9WkfN3B6Ab0F5V97if44Fn8ojZFAFLKKY4fOYWrwBEAx+ISDOcri1C3eGfAt/jHHSvxin2ALgAp2PCrHL6cKDBacbRE/cApKqzxKnziQZ+BV4WkfHAF6qaLDlXRZyOrE4FE3CK0fLzK/C+iHyaNa+qbsXpRiM7f3uLLeqesF/JVrS5wWdcfkVetXEeB+CP3L47AN/7JBNwOnz0TWymGFiRlykOh3zePw3MVucJjwNwEgTqPFtlt1sMNQTnigWcg+EgVY1zXw1UNa8OKJcDnXIZl+OBVVXHALcBFYH5ItLS3w3DebKf7+8o+yOQs868M/DjBE5VRwCP4/QCmygiMXlMnozTQ2yW3HqLLWyvsnnt08I6wsn7LK915fjdcR3KNm24u2xTjCyhmOIWDWxx39+UbdwEnPL6aFVd6g77DrjXrZxFRDrks/zXgWEiclbWABG5XkTOwHmE81B3WB9gl6ruF5EmqrpUVZ/HKSppCRzAqQjOWkZdEfkhh/XtAGq6VzthQEGLyLKvp4mqLlDVkcAuTk4EJ3HrPg6IyNnu/rmRnHuFngpcIyJhbhFTM+C3AsT4IvCoiDR3YwwSkQcLMH9e1nDylVte/7+8vjvZNcfpsNQUI0sopri9ADwnIr/iPIPe1ySc1kif+gx7GqdoY4lb+f10XgtX1R3uMl4Sp9npSqAXsB8YDXQWkSU4le5ZXZj/JasiHOes9hucXmbT3crxB3CKZk5poaaqx4GncJ7mNx2nnL8gpgFXZFXKAy+K0wx4GU4CXCwidUTk61zmvxPnsbzrcHqN/QZARC4TkafcGJfj7NMVOJXfd2cVQYrICyKSDESISHJWg4Js27gE+Avwibs/l7n7o9BU9RCQJCJN3c95/f/y+u5kdy7wVSBiNP6z3oaN8YOI3ANsUtXS/IybEklErgA6qerjAVzmT8BAVd0bqGWa/FlCMcZ4TkRuU9V3ArSsGkAPVf0yEMsz/rOEYowxJiCsDsUYY0xAWEIxxhgTEJZQjDHGBIQlFGOMMQFhCcUYY0xA/D88LGFFXLnkrgAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x118b4c7d0>"
+       "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -1741,34 +1817,25 @@
     "plt.legend(loc='best')\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/src/pylogit/newsfragments/69.trivial
+++ b/src/pylogit/newsfragments/69.trivial
@@ -1,1 +1,0 @@
-Update example Prediction with PyLogit notebook from pd.Series.sort to pd.Series.sort_values

--- a/src/pylogit/newsfragments/69.trivial
+++ b/src/pylogit/newsfragments/69.trivial
@@ -1,0 +1,1 @@
+Update example Prediction with PyLogit notebook from pd.Series.sort to pd.Series.sort_values

--- a/src/pylogit/newsfragments/72.trivial
+++ b/src/pylogit/newsfragments/72.trivial
@@ -1,0 +1,1 @@
+Update example Prediction with PyLogit notebook from pd.Series.sort to pd.Series.sort_values


### PR DESCRIPTION
Change file /examples/notebooks/Prediction with PyLogit.ipynb: 
From:
```
pd.Series(prediction_log_likelihoods,
          name="Log-likelihood of Predictions").sort(inplace=False)
```
To:

```
pd.Series(prediction_log_likelihoods,
          name="Log-likelihood of Predictions").sort_values(inplace=False)
```
As both .sort() and order() functions are DEPRECATED
.sort_values() function is the replacement and here's the example on how to use it

Source: https://stackoverflow.com/questions/24049509/why-calling-sort-function-on-pandas-series-sorts-its-values-in-place-and-retu