### PR TITLE
Performance optimization for large matrices

### DIFF
--- a/src/pylogit/choice_calcs.py
+++ b/src/pylogit/choice_calcs.py
@@ -925,10 +925,11 @@ def calc_fisher_info_matrix(beta,
                                     return_long_probs=True)
 
     # Calculate the weights for the sample
-    if weights is None:
-        weights = np.ones(design.shape[0])
-    weights_per_obs =\
-        np.max(rows_to_obs.toarray() * weights[:, None], axis=0)
+    if weights is None or np.all(weights == 1):
+        weights_per_obs = np.ones(rows_to_obs.shape[1])
+    else:
+        weights_per_obs = \
+            np.max(rows_to_obs.toarray() * weights[:, None], axis=0)
 
     ##########
     # Get the required matrices


### PR DESCRIPTION
Computes `weghts_per_obs` only when required

* In case `weights` given for calculating the weighted log-likelihood are none or ones, then there is no need to perform the multiplication and max operations over the `rows_to_obs` matrix, since it can lead to an out of memory error for very large matrices. Instead, just set `weights_per_obs` to an array of ones.
