### PR TITLE
Remove deprecated collections.Iterable import

### DIFF
--- a/src/pylogit/choice_tools.py
+++ b/src/pylogit/choice_tools.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 
 import warnings
 from collections import OrderedDict
-from collections import Iterable
+from collections.abc import Iterable
 from numbers import Number
 
 import numpy as np

--- a/tests/test_bootstrap_abc.py
+++ b/tests/test_bootstrap_abc.py
@@ -2,7 +2,7 @@
 Tests for the bootstrap_abc.py file.
 """
 import unittest
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import numpy.testing as npt


### PR DESCRIPTION
Python 3.10 removed some deprecated aliases from `collections` that live in `collections.abc` since 3.3, most notably `Iterable`. Should be a safe change for anything >= Python 3.3, seems like this is enough to get things working on 3.10 (or at least importable).